### PR TITLE
fix: update devcontainer.json to pin azd version to 1.16.1 instead of latest

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "name": "Azure Developer CLI",
   "image": "mcr.microsoft.com/devcontainers/python:3.10-bullseye",
   "features": {
+    // See https://containers.dev/features for list of features
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/azure-cli:1": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,10 @@
 
   {
-    "name": "Azure Developer CLI",
-    "image": "mcr.microsoft.com/devcontainers/python:3.10-bullseye",
-    "features": {
-        // See https://containers.dev/features for list of features
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/azure/azure-dev/azd:latest": {},
-        "ghcr.io/devcontainers/features/azure-cli:1": {}
-    }
+  "name": "Azure Developer CLI",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/azure-cli:1": {}
+  },
+  "postCreateCommand": "curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version 1.16.1"
 }


### PR DESCRIPTION
This commit updates the devcontainer.json configuration to explicitly pin the Azure Developer CLI (azd) version to 1.16.1.
We observed that deployments were failing with the latest azd version (1.17), and reverting to 1.16.1 resolved the issue.