### PR TITLE
fix: Code changes & document changes related to AZD issues with 1.17.0 version

### DIFF
--- a/docs/github_code_spaces_steps.md
+++ b/docs/github_code_spaces_steps.md
@@ -45,6 +45,8 @@ You can run this solution using GitHub Codespaces. The button will open a web-ba
 
 10. Now start the deployment of the infrastructure by typing the command “azd up”
 
+    > ⚠️ **Note:** The latest version of the Azure Developer CLI (AZD) is currently limited on prompting for missing parameters. The feature flag parameters in this solution have been temporarily defaulted to `'disabled'` until this limitation is lifted and prompting will resume.
+
     ![image showing the terminal in vs code](../img/provisioning/azd_provision_terminal.png)
 
     This step will allow you to choose from the subscriptions you have available, based on the account you logged in with in the login step. Next it will prompt you for the region to deploy the resources into as well as any additional Azure resources to be provisioned and configured.

--- a/docs/local_environment_steps.md
+++ b/docs/local_environment_steps.md
@@ -30,12 +30,13 @@ azd env new '<app name>'
 ```
 
 Optionally set environment variables via the following commands:
-
 ```powershell
 azd env set 'AZURE_VM_ADMIN_PASSWORD' '<secure password>'
 ```
 
 # Deploy
+
+> ⚠️ **Note:** The latest version of the Azure Developer CLI (AZD) is currently limited on prompting for missing parameters. The feature flag parameters in this solution have been temporarily defaulted to `'disabled'` until this limitation is lifted and prompting will resume.
 
 To provision the necessary Azure resources and deploy the application, run the azd up command:
 ```powershell

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,7 +15,7 @@ param connections connectionType[] = []
 param aiModelDeployments deploymentsType[] = []
 
 @description('Specifies whether creating an Azure Container Registry.')
-param acrEnabled bool 
+param acrEnabled bool = false
 
 @description('Specifies the size of the jump-box Virtual Machine.')
 param vmSize string = 'Standard_DS4_v2'
@@ -41,7 +41,7 @@ param userObjectId string = deployer().objectId
 param allowedIpAddress string = ''
 
 @description('Specifies if Microsoft APIM is deployed.')
-param apiManagementEnabled bool 
+param apiManagementEnabled bool = false
 
 @description('Specifies the publisher email for the API Management service. Defaults to admin@[name].com.')
 param apiManagementPublisherEmail string = 'admin@${name}.com'
@@ -50,37 +50,37 @@ param apiManagementPublisherEmail string = 'admin@${name}.com'
 param networkIsolation bool = true
 
 @description('Whether to include Cosmos DB in the deployment.')
-param cosmosDbEnabled bool 
+param cosmosDbEnabled bool = false
 
 @description('Optional. List of Cosmos DB databases to deploy.')
 param cosmosDatabases sqlDatabaseType[] = []
 
 @description('Whether to include SQL Server in the deployment.')
-param sqlServerEnabled bool 
+param sqlServerEnabled bool = false
 
 @description('Optional. List of SQL Server databases to deploy.')
 param sqlServerDatabases databasePropertyType[] = []
 
 @description('Whether to include Azure AI Search in the deployment.')
-param searchEnabled bool
+param searchEnabled bool = false
 
 @description('Whether to include Azure AI Content Safety in the deployment.')
-param contentSafetyEnabled bool
+param contentSafetyEnabled bool = false
 
 @description('Whether to include Azure AI Vision in the deployment.')
-param visionEnabled bool
+param visionEnabled bool = false
 
 @description('Whether to include Azure AI Language in the deployment.')
-param languageEnabled bool
+param languageEnabled bool = false
 
 @description('Whether to include Azure AI Speech in the deployment.')
-param speechEnabled bool
+param speechEnabled bool = false
 
 @description('Whether to include Azure AI Translator in the deployment.')
-param translatorEnabled bool
+param translatorEnabled bool = false
 
 @description('Whether to include Azure Document Intelligence in the deployment.')
-param documentIntelligenceEnabled bool
+param documentIntelligenceEnabled bool = false
 
 var defaultTags = {
   'azd-env-name': name


### PR DESCRIPTION
This pull request includes updates to the Azure infrastructure deployment configuration and documentation. The main changes involve defaulting certain feature flags to disabled in `bicep` and `json` templates, updating the Azure Developer CLI (AZD) version, and adding notes to the documentation about AZD limitations. These changes aim to improve deployment reliability and clarify instructions for users.

### Documentation Updates:
* Added notes in `docs/github_code_spaces_steps.md` and `docs/local_environment_steps.md` about AZD's current limitation in prompting for missing parameters, with feature flags defaulted to `'disabled'`