### PR TITLE
fix: Modified the branch name in scripts

### DIFF
--- a/scripts/index_scripts/02_process_data.py
+++ b/scripts/index_scripts/02_process_data.py
@@ -142,7 +142,7 @@ def load_pdfs_from_github():
     owner = "microsoft"
     repo = "Deploy-Your-AI-Application-In-Production"
     path = "data"
-    branch = "data-ingestionscript"
+    branch = "main"
     headers = {
         "Cache-Control": "no-cache",
         "User-Agent": "Mozilla/5.0"

--- a/scripts/process_sample_data.ps1
+++ b/scripts/process_sample_data.ps1
@@ -29,7 +29,7 @@ Write-Host "`n===================== Starting Script ====================="
 
 if (-not $UseLocalFiles) {
     # GitHub repo base path
-    $baseUrl = "https://raw.githubusercontent.com/microsoft/Deploy-Your-AI-Application-In-Production/data-ingestionscript/scripts/index_scripts"
+    $baseUrl = "https://raw.githubusercontent.com/microsoft/Deploy-Your-AI-Application-In-Production/main/scripts/index_scripts"
 
     # Script list
     $scripts = @("01_create_search_index.py", "02_process_data.py", "requirements.txt")


### PR DESCRIPTION
This pull request updates branch references in the repository to ensure compatibility with the latest code structure. Specifically, it replaces references to the outdated `data-ingestionscript` branch with the `main` branch.

Branch reference updates:

* [`scripts/index_scripts/02_process_data.py`](diffhunk://#diff-6eaefb597ee32f420cf69fe025e37a92d9f34dba9a3ebcf45398446b90ae2975L145-R145): Updated the `branch` variable in the `load_pdfs_from_github` function to use the `main` branch instead of `data-ingestionscript`.
* [`scripts/process_sample_data.ps1`](diffhunk://#diff-1da28aa143b2fc3cdeae63f692d7cf3b3cc0bc3b879b5bc5f5ae2ff590eee1b9L32-R32): Modified the `$baseUrl` variable to point to the `main` branch instead of `data-ingestionscript`.