### PR TITLE
fix: Deployment failure for Storage account if env name has special characters

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -128,6 +128,7 @@ var defaultTags = {
 var allTags = union(defaultTags, tags)
 
 var resourceToken = substring(uniqueString(subscription().id, location, name), 0, 5)
+var sanitizedName = toLower(replace(replace(replace(replace(replace(replace(replace(replace(replace(name, '@', ''), '#', ''), '$', ''), '!', ''), '-', ''), '_', ''), '.', ''), ' ', ''), '&', ''))
 var servicesUsername = take(replace(vmAdminUsername,'.', ''), 20)
 
 var deploySampleApp = appSampleEnabled && cosmosDbEnabled && searchEnabled && !empty(authClientId) && !empty(authClientSecret) && !empty(cosmosDatabases) && !empty(aiGPTModelDeployment) && length(aiEmbeddingModelDeployment) >= 2
@@ -229,7 +230,7 @@ module containerRegistry 'modules/containerRegistry.bicep' = if (acrEnabled) {
 module storageAccount 'modules/storageAccount.bicep' = {
   name: take('${name}-storage-account-deployment', 64)
   params: {
-    storageName: 'st${name}${resourceToken}'
+    storageName: 'st${sanitizedName}${resourceToken}'
     location: location
     networkIsolation: networkIsolation
     virtualNetworkResourceId: networkIsolation ? network.outputs.resourceId : ''


### PR DESCRIPTION
This pull request introduces a sanitization process for resource names in the `infra` project to ensure compliance with Azure naming conventions. The changes primarily focus on replacing invalid characters in resource names and updating references to use the sanitized names.

### Resource Name Sanitization:
* **Sanitization Logic Added**: Introduced a new variable, `sanitizedName`, in `infra/main.bicep` to remove invalid characters (e.g., `@`, `#`, `, `!`, `-`, `_`, `.`, ` `, `&`) from resource names. This ensures compatibility with Azure's naming rules.
* **Updated Storage Account Name**: Modified the `storageName` parameter in the storage account module to use `sanitizedName` instead of the raw `name` variable, ensuring sanitized resource names are applied.
