### PR TITLE
fix: Shell script causing deployment to fail due to incorrect exit code

### DIFF
--- a/scripts/auth_init.sh
+++ b/scripts/auth_init.sh
@@ -4,7 +4,7 @@
 
 if [ "$AZURE_APP_SAMPLE_ENABLED" = "false" ]; then
     echo "AZURE_APP_SAMPLE_ENABLED is false. Exiting auth_init script."
-    exit 1
+    exit 0
 fi
 
 echo 'Running "auth_init.py"'

--- a/scripts/postprovision.sh
+++ b/scripts/postprovision.sh
@@ -4,7 +4,7 @@
 
 if [ "$AZURE_APP_SAMPLE_ENABLED" = "false" ]; then
     echo "AZURE_APP_SAMPLE_ENABLED is false. Exiting auth_update script."
-    exit 1
+    exit 0
 fi
 
 echo 'Running "auth_update.py"'


### PR DESCRIPTION
This pull request modifies the behavior of two scripts to ensure they exit successfully when the `AZURE_APP_SAMPLE_ENABLED` environment variable is set to `false`. Previously, the scripts would terminate with an error in this scenario.

### Changes to script exit behavior:

* [`scripts/auth_init.sh`](diffhunk://#diff-b3d00f1292d6a8bb23c8aab1a1a469d5e989b5c694326f20f36265cb073ce246L7-R7): Updated the script to exit with a success code (`exit 0`) instead of an error code (`exit 1`) when `AZURE_APP_SAMPLE_ENABLED` is `false`.
* [`scripts/postprovision.sh`](diffhunk://#diff-10742659ca6330fe03b43c59f178d0f493551912a18ac66e53316f829d80c708L7-R7): Similarly updated the script to exit with a success code (`exit 0`) instead of an error code (`exit 1`) when `AZURE_APP_SAMPLE_ENABLED` is `false`.