### PR TITLE
fix: add bicep version requirement (>= 0.33.0) to azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -2,6 +2,7 @@ name: deploy-your-ai-application-in-production
 
 requiredVersions:
   azd: ">=1.15.0 != 1.23.9"
+  bicep: '>= 0.33.0'
 
 infra:
   provider: "bicep"


### PR DESCRIPTION
## Summary\n\nAdds `bicep: '>= 0.33.0'` to the `requiredVersions` section in `azure.yaml`.\n\nThis ensures the correct Bicep CLI version is used during `azd` deployments.\n\n## Changes\n- Added `bicep: '>= 0.33.0'` under `requiredVersions` in `azure.yaml`