### PR TITLE
chore: Enhance deployment guides and improve OneLake data source creation

### DIFF
--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -191,6 +191,42 @@ Edit `infra/main.bicepparam` or set environment variables:
 # var fabricWorkspacePreset = 'none'
 ```
 
+#### Reusing an Existing Fabric Capacity and Workspace (BYO mode)
+
+If you already have a Fabric capacity and workspace, set `byo` mode so the deployment skips creating new ones. The bicepparam variables are driven by environment variables, so the recommended approach is to set them with `azd env set` before running `azd up`:
+
+**Step 1 — Set the mode in `infra/main.bicepparam`** (or leave the default `byo` unchanged):
+
+```bicep
+// infra/main.bicepparam
+var fabricCapacityPreset = readEnvironmentVariable('fabricCapacityMode', 'byo')
+```
+
+The `fabricCapacityMode` env variable controls both capacity and workspace preset (they are tied together). Set it explicitly if the checked-in default has been changed:
+
+```powershell
+azd env set fabricCapacityMode byo
+```
+
+**Step 2 — Supply the existing resource identifiers:**
+
+```powershell
+# ARM resource ID of the existing Fabric capacity
+azd env set fabricCapacityResourceId "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Fabric/capacities/<capacity-name>"
+
+# GUID of the existing Fabric workspace (from the workspace URL or Fabric portal)
+azd env set FABRIC_WORKSPACE_ID "<workspace-guid>"
+
+# Display name of the existing workspace (used for naming/UX; optional but recommended)
+azd env set FABRIC_WORKSPACE_NAME "<workspace-display-name>"
+```
+
+> **How to find the workspace GUID:** Open the workspace in [app.fabric.microsoft.com](https://app.fabric.microsoft.com), copy the URL. The segment after `/groups/` is the workspace GUID (e.g., `https://app.fabric.microsoft.com/groups/e9c7ed61-0cdc-4356-a239-9d49cc755fe0/...` → `e9c7ed61-0cdc-4356-a239-9d49cc755fe0`).
+
+> **How to find the capacity resource ID:** In Azure Portal, open the Fabric capacity resource → **Properties** → copy **Resource ID**. It follows the pattern `/subscriptions/.../providers/Microsoft.Fabric/capacities/<name>`.
+
+After setting these variables, run `azd up` normally. The deployment will attach to your existing capacity and workspace instead of creating new ones.
+
 </details>
 
 <details>

--- a/docs/parameter_guide.md
+++ b/docs/parameter_guide.md
@@ -8,11 +8,79 @@ This guide focuses on configuration concepts for the **AI Landing Zone**.
 > - AI Landing Zone submodule parameters file (if you deploy it directly): `submodules/ai-landing-zone/main.parameters.json`
 >
 > **Fabric options in this repo** are configured in `infra/main.bicepparam` via:
-> - `fabricCapacityPreset` (`create` | `byo` | `none`)
-> - `fabricWorkspacePreset` (`create` | `byo` | `none`)
-> - BYO inputs: `fabricCapacityResourceId`, `fabricWorkspaceId`, `fabricWorkspaceName`
+> - `fabricCapacityPreset` (`create` | `byo` | `none`) — driven by the `fabricCapacityMode` env variable
+> - `fabricWorkspacePreset` (`create` | `byo` | `none`) — mirrors `fabricCapacityPreset` by default
+> - BYO inputs: `fabricCapacityResourceId` (env), `FABRIC_WORKSPACE_ID` (env), `FABRIC_WORKSPACE_NAME` (env)
 
 > **Deployment flow**: This repo deploys the AI Landing Zone submodule from `submodules/ai-landing-zone/main.bicep` during the preprovision hook. The single source of truth for parameters is `infra/main.bicepparam`.
+
+## Fabric Configuration
+
+### Modes: create, byo, none
+
+| Mode | Description |
+|------|-------------|
+| `create` | Provisions a new Fabric capacity (Bicep) and workspace (postprovision script) |
+| `byo` | Reuses an existing Fabric capacity and workspace — no new resources created |
+| `none` | Disables all Fabric automation; OneLake indexing will be skipped |
+
+Both capacity and workspace modes are controlled by the same `fabricCapacityMode` environment variable (they are tied together in `infra/main.bicepparam`).
+
+### Setting Mode via azd env
+
+The recommended way to configure Fabric mode is with `azd env set` — these values are read directly by `infra/main.bicepparam` at provision time:
+
+```powershell
+# Choose one:
+azd env set fabricCapacityMode create   # create new capacity + workspace
+azd env set fabricCapacityMode byo      # reuse existing capacity + workspace (default)
+azd env set fabricCapacityMode none     # disable all Fabric automation
+```
+
+### Reusing Existing Fabric Resources (BYO)
+
+When `fabricCapacityMode` is `byo`, supply the identifiers of your existing resources:
+
+```powershell
+# ARM resource ID of the existing Fabric capacity
+azd env set fabricCapacityResourceId "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Fabric/capacities/<capacity-name>"
+
+# GUID of the existing Fabric workspace (from the workspace URL)
+azd env set FABRIC_WORKSPACE_ID "<workspace-guid>"
+
+# Display name of the existing workspace (optional, used for naming/UX)
+azd env set FABRIC_WORKSPACE_NAME "<workspace-display-name>"
+```
+
+> **How to find the workspace GUID:** Open the workspace in [app.fabric.microsoft.com](https://app.fabric.microsoft.com). The URL segment after `/groups/` is the GUID (e.g., `https://app.fabric.microsoft.com/groups/e9c7ed61-0cdc-4356-a239-9d49cc755fe0/...`).
+>
+> **How to find the capacity resource ID:** Azure Portal → Fabric capacity resource → **Properties** → **Resource ID**.
+
+You can also set these directly in `infra/main.bicepparam` if you prefer source-controlled values:
+
+```bicep
+// infra/main.bicepparam
+var fabricCapacityPreset = 'byo'
+param fabricCapacityResourceId = '/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Fabric/capacities/<name>'
+param fabricWorkspaceId = '<workspace-guid>'
+param fabricWorkspaceName = '<workspace-display-name>'
+```
+
+> **Note:** Values set via `azd env set` take precedence over hardcoded bicepparam values because `readEnvironmentVariable(...)` is evaluated at deploy time.
+
+### Creating New Fabric Resources
+
+When `fabricCapacityMode` is `create`, you must provide at least one admin principal:
+
+```bicep
+// infra/main.bicepparam
+param fabricCapacityAdmins = ['user@contoso.com']
+param fabricCapacitySku = 'F2'  // adjust SKU as needed
+```
+
+> **Permission requirement:** The identity running `azd` must have the **Fabric Administrator** role (or Power BI tenant admin) to call the workspace admin APIs used during postprovision.
+
+---
 
 ## Table of Contents
 1. [Basic Parameters](#basic-parameters)

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -235,11 +235,11 @@ var fabricWorkspacePreset = fabricCapacityPreset
 param deployFabricCapacity = fabricCapacityPreset != 'none'
 
 param fabricCapacityMode = fabricCapacityPreset
-param fabricCapacityResourceId = '' // required when fabricCapacityPreset='byo'
+param fabricCapacityResourceId = readEnvironmentVariable('fabricCapacityResourceId', '') // required when fabricCapacityPreset='byo'
 
 param fabricWorkspaceMode = fabricWorkspacePreset
-param fabricWorkspaceId = '' // required when fabricWorkspacePreset='byo'
-param fabricWorkspaceName = '' // optional (helpful for naming/UX)
+param fabricWorkspaceId = readEnvironmentVariable('FABRIC_WORKSPACE_ID', readEnvironmentVariable('fabricWorkspaceId', '')) // required when fabricWorkspacePreset='byo'
+param fabricWorkspaceName = readEnvironmentVariable('FABRIC_WORKSPACE_NAME', readEnvironmentVariable('fabricWorkspaceName', '')) // optional (helpful for naming/UX)
 
 // Fabric capacity SKU.
 param fabricCapacitySku = 'F8'

--- a/scripts/automationScripts/FabricWorkspace/CreateWorkspace/create_lakehouses.ps1
+++ b/scripts/automationScripts/FabricWorkspace/CreateWorkspace/create_lakehouses.ps1
@@ -302,6 +302,13 @@ if ($names -contains "bronze") {
         } else {
           Set-Content -Path $workspaceEnvPath -Value $lakehouseExports
         }
+
+        # Persist lakehouse IDs in azd env so downstream hooks and reruns can find them
+        try { azd env set FABRIC_LAKEHOUSE_ID $bronzeLakehouse.id } catch {}
+        foreach ($lakehouse in $existingLakehouses.value) {
+          $lhName = if ($null -ne $lakehouse.PSObject.Properties['displayName']) { $lakehouse.displayName } else { $lakehouse.name }
+          try { azd env set "FABRIC_LAKEHOUSE_${lhName}_ID" $lakehouse.id } catch {}
+        }
         
       } catch {
         Warn "Failed to export lakehouse IDs: $($_.Exception.Message)"

--- a/scripts/automationScripts/OneLakeIndex/04_create_onelake_datasource.ps1
+++ b/scripts/automationScripts/OneLakeIndex/04_create_onelake_datasource.ps1
@@ -86,6 +86,19 @@ if (-not $subscription) { $subscription = $env:AZURE_SUBSCRIPTION_ID }
 if (-not $workspaceId) { $workspaceId = $env:FABRIC_WORKSPACE_ID }
 if (-not $lakehouseId) { $lakehouseId = $env:FABRIC_LAKEHOUSE_ID }
 
+# Try azd outputs (Bicep emits fabricWorkspaceIdOut for BYO mode)
+if (-not $workspaceId -and $outputs) {
+    if ($outputs.fabricWorkspaceIdOut -and $outputs.fabricWorkspaceIdOut.value) { $workspaceId = $outputs.fabricWorkspaceIdOut.value }
+    elseif ($outputs.fabricWorkspaceId -and $outputs.fabricWorkspaceId.value) { $workspaceId = $outputs.fabricWorkspaceId.value }
+}
+if (-not $lakehouseId -and $outputs) {
+    if ($outputs.fabricLakehouseId -and $outputs.fabricLakehouseId.value) { $lakehouseId = $outputs.fabricLakehouseId.value }
+}
+
+# Try azd env store (persisted by create_lakehouses.ps1)
+if (-not $workspaceId) { try { $val = & azd env get-value FABRIC_WORKSPACE_ID 2>$null; if ($val) { $workspaceId = $val.ToString().Trim() } } catch {} }
+if (-not $lakehouseId) { try { $val = & azd env get-value FABRIC_LAKEHOUSE_ID 2>$null; if ($val) { $lakehouseId = $val.ToString().Trim() } } catch {} }
+
 # Try temp fabric_workspace.env (from create_fabric_workspace.ps1)
 if ((-not $workspaceId -or -not $lakehouseId) -and (Test-Path (Join-Path ([IO.Path]::GetTempPath()) 'fabric_workspace.env'))) {
     Get-Content (Join-Path ([IO.Path]::GetTempPath()) 'fabric_workspace.env') | ForEach-Object {


### PR DESCRIPTION



## Purpose

This pull request introduces significant improvements to the configuration and automation of Microsoft Fabric resource deployment, especially around "bring your own" (BYO) scenarios. The changes enhance environment variable management, clarify documentation, and improve the robustness of resource ID handling across deployment scripts.

**Key changes:**

### Documentation and Configuration Improvements

* Expanded documentation in `docs/parameter_guide.md` and `docs/deploymentguide.md` to clearly explain the different Fabric deployment modes (`create`, `byo`, `none`), how to configure them via environment variables, and step-by-step instructions for BYO scenarios. This includes guidance on setting and discovering required resource IDs and workspace GUIDs. [[1]](diffhunk://#diff-b75bd01003dbd9073f81a337499d36462abafb67b80b72cb6dffea5c772b99a0L11-R84) [[2]](diffhunk://#diff-7da2b2ea366c9b02288cd8c19cd2695f34b66c636334b3ba3fcb31c96c35ecc9R194-R229)
* Updated parameter names and descriptions to clarify that the `fabricCapacityMode` environment variable is the primary control point for both capacity and workspace presets, and that BYO inputs are now expected as environment variables.

### Environment Variable Handling in Bicep

* Modified `infra/main.bicepparam` to read `fabricCapacityResourceId`, `fabricWorkspaceId`, and `fabricWorkspaceName` directly from environment variables (using `readEnvironmentVariable`), improving flexibility and alignment with deployment practices.

### Automation Script Enhancements

* Updated `create_lakehouses.ps1` to persist lakehouse IDs into the azd environment store after creation, enabling downstream scripts and reruns to reliably locate existing lakehouses.
* Improved `04_create_onelake_datasource.ps1` to robustly resolve workspace and lakehouse IDs by checking azd outputs, the azd environment store, and fallback temp files, ensuring compatibility with both BYO and newly created resources.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->