### PR TITLE
fix: address PR review comments on workflow files

### DIFF
--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEMP: /tmp
           fabricCapacityMode: 'none'
-          AZURE_PRINCIPAL_ID: ${{ vars.PRINCIPAL_ID || secrets.AZURE_CLIENT_ID }}
+          AZURE_PRINCIPAL_ID: ${{ vars.PRINCIPAL_ID || secrets.AZURE_PRINCIPAL_ID }}
           AZURE_PRINCIPAL_TYPE: 'ServicePrincipal'
       - name: print result
         run: cat ${{ steps.validation.outputs.resultFile }}

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -83,8 +83,8 @@ jobs:
             echo "Resource group already exists: $RESOURCE_GROUP"
           fi
 
-          # Set for subsequent steps
-          echo "RESOURCE_GROUP=$RESOURCE_GROUP" >> $GITHUB_ENV
+          # Export as AZURE_RESOURCE_GROUP so azd provision picks up the correct RG
+          echo "AZURE_RESOURCE_GROUP=$RESOURCE_GROUP" >> $GITHUB_ENV
 
       - name: Provision Infrastructure
         id: provision-main


### PR DESCRIPTION

## Purpose
- azure-dev.yml: Export derived RG name as AZURE_RESOURCE_GROUP (not RESOURCE_GROUP) so azd provision picks up the correct resource group when vars.AZURE_RESOURCE_GROUP is empty.

- azd-template-validation.yml: Use secrets.AZURE_PRINCIPAL_ID instead of secrets.AZURE_CLIENT_ID as fallback for AZURE_PRINCIPAL_ID. Client ID is not the SP object ID and causes RBAC assignment failures.

* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->