### PR TITLE
fix: remove hardcoded VM password, secure credential docs, and eliminate eval in quota script

### DIFF
--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -209,15 +209,10 @@ For network-isolated deployments, set the VM credentials before running `azd up`
 
 ```powershell
 azd env set VM_ADMIN_USERNAME "youradminuser"
-azd env set VM_ADMIN_PASSWORD "Use-A-Strong-Password-Here!"
+azd env set VM_ADMIN_PASSWORD "<your-strong-password>"
 ```
 
-If you prefer source-controlled defaults, set them in [infra/main.bicepparam](../infra/main.bicepparam) instead:
-
-```bicep
-param vmUserName = 'youradminuser'
-param vmAdminPassword = 'Use-A-Strong-Password-Here!'
-```
+> ⚠️ **Security Warning:** Do **not** commit VM passwords to source control. Always use `azd env set`, a secrets manager, or pipeline secret variables for sensitive credentials. The `infra/main.bicepparam` file reads the password from the `VM_ADMIN_PASSWORD` environment variable at deployment time — no default is provided intentionally, so deployment will prompt or fail if the variable is unset.
 
 </details>
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -205,7 +205,7 @@ param containerAppsList = [
 ]
 
 param vmUserName = readEnvironmentVariable('VM_ADMIN_USERNAME', 'testvmuser')
-param vmAdminPassword = readEnvironmentVariable('VM_ADMIN_PASSWORD', 'JumpboxAdminP@ssw0rd1234!')
+param vmAdminPassword = readEnvironmentVariable('VM_ADMIN_PASSWORD', '')
 param vmSize = 'Standard_D2s_v4'
 
 // ========================================

--- a/scripts/quota_check.sh
+++ b/scripts/quota_check.sh
@@ -180,6 +180,7 @@ MODEL_COUNT=${#MODEL_NAMES[@]}
 
 # ---- Results tracking ----
 declare -A REGION_STATUS
+declare -A RESULTS
 VALID_REGIONS=()
 
 # ---- Main quota check loop ----
@@ -213,7 +214,7 @@ for REGION in "${REGIONS[@]}"; do
                 echo "      (Looked for: $primary_key${alt_key:+, $alt_key})"
             fi
             ALL_PASS=false
-            eval "RESULT_${safe_region}_${i}=N_A"
+            RESULTS["${safe_region}:${i}"]="N_A"
             continue
         fi
 
@@ -223,7 +224,7 @@ for REGION in "${REGIONS[@]}"; do
         LIMIT=${LIMIT%%.*}
         AVAILABLE=$((LIMIT - CURRENT))
 
-        eval "RESULT_${safe_region}_${i}=${AVAILABLE}_${LIMIT}"
+        RESULTS["${safe_region}:${i}"]="${AVAILABLE}_${LIMIT}"
 
         if [[ "$AVAILABLE" -lt "$mcap" ]]; then
             echo "   ❌ $display | Used: $CURRENT | Limit: $LIMIT | Available: $AVAILABLE | Need: $mcap"
@@ -291,7 +292,7 @@ for REGION in "${REGIONS[@]}"; do
 
     for ((i=0; i<MODEL_COUNT; i++)); do
         mcap="${MODEL_CAPS[$i]}"
-        eval "val=\${RESULT_${safe_region}_${i}:-N_A}"
+        val="${RESULTS["${safe_region}:${i}"]:-N_A}"
 
         if [[ "$val" == "N_A" ]]; then
             printf "%-30s" "⚠️  N/A"


### PR DESCRIPTION
## Purpose

Addresses security and code quality concerns identified by GitHub Copilot code reviews on PR #131. This PR makes three targeted fixes:

1. **Remove hardcoded VM password default** (`infra/main.bicepparam`): The `vmAdminPassword` parameter previously used `readEnvironmentVariable('VM_ADMIN_PASSWORD', 'JumpboxAdminP@ssw0rd1234!')` - a known credential deployed by default. Changed the fallback to an empty string so deployment requires explicit credential configuration via `azd env set`.

2. **Update deployment guide security guidance** (`docs/deploymentguide.md`): Removed documentation that encouraged committing VM passwords to source control via `main.bicepparam`. Replaced with a security warning recommending `azd env set`, secrets managers, or pipeline secret variables.

3. **Replace unsafe eval with associative array** (`scripts/quota_check.sh`): Replaced `eval`-based dynamic variable names with a `declare -A` associative array keyed by `region:index`. This eliminates potential code-injection risks and improves script maintainability. Tested and verified the script runs correctly with the new approach.

**Cross-repo alignment:** All other Microsoft solution accelerators (Content Generation, Code Modernization, DKM, Container Migration, RTI, BYOCC, etc.) use pure environment variable substitution with **no hardcoded password defaults** for VM credentials. This fix aligns Deploy-Your-AI-Application-In-Production with that established security pattern.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

> Existing deployments that already set `VM_ADMIN_PASSWORD` via `azd env set` are unaffected. Deployments relying on the hardcoded default will now need to explicitly set the password - this is the intended behavior to prevent insecure defaults. The quota check script behavior is unchanged - only internal variable storage mechanism was refactored.

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

> Quota check script tested with `--regions eastus,westus --verbose` and confirmed correct quota retrieval, summary table rendering, and pass/fail reporting.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

> Infrastructure parameter and documentation change. Quota check script is a pre-deployment utility and does not affect runtime services.

## What to Check
Verify that the following are valid:
* `azd env set VM_ADMIN_PASSWORD "<strong-password>"` followed by `azd up` deploys the Jump VM successfully
* Deployment without setting `VM_ADMIN_PASSWORD` prompts or fails gracefully (no hardcoded password deployed)
* Documentation in `docs/deploymentguide.md` renders correctly with the security warning
* `./scripts/quota_check.sh --regions eastus,westus --verbose` runs correctly and displays quota summary table

## Other Information

* Related to Copilot review findings on #131:
  - Hardcoded password in `main.bicepparam` (line 208)
  - Insecure documentation guidance in `deploymentguide.md` (line 219)
  - Unsafe `eval` usage in `quota_check.sh` (lines 191, 216, 226, 294)
* Follows VM credential patterns from peer accelerators: Content Generation, Code Modernization, DKM, Container Migration
