### PR TITLE
fix: Update AVM and Bicep API versions

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -2,7 +2,6 @@ name: deploy-your-ai-application-in-production
 
 requiredVersions:
   azd: ">=1.15.0 != 1.23.9"
-  bicep: '>= 0.33.0'
 
 infra:
   provider: "bicep"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -273,7 +273,7 @@ param postgreSqlFabricUserSecretName string = 'postgres-fabric-user-password'
 param postgreSqlMirrorConnectionMode string = 'fabricUser'
 
 @description('Authentication configuration for PostgreSQL Flexible Server. Defaults to both Microsoft Entra and password authentication enabled so Fabric mirroring can be configured immediately after deployment.')
-param postgreSqlAuthConfig resourceInput<'Microsoft.DBforPostgreSQL/flexibleServers@2025-06-01-preview'>.properties.authConfig = {
+param postgreSqlAuthConfig resourceInput<'Microsoft.DBforPostgreSQL/flexibleServers@2025-08-01'>.properties.authConfig = {
   activeDirectoryAuth: 'Enabled'
   passwordAuth: 'Enabled'
 }
@@ -369,17 +369,17 @@ var effectivePostgreSqlAdminPassword = postgreSqlAdminPassword == '$(secretOrRan
   ? '${uniqueString(subscription().id, resourceGroup().id, postgreSqlServerName)}!${replace(generatedPostgreSqlAdminPassword, '-', '')}'
   : postgreSqlAdminPassword
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: last(split(effectiveKeyVaultResourceId, '/'))
 }
 
-resource postgreSqlPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (deployPostgreSql && postgreSqlNetworkIsolation) {
+resource postgreSqlPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (deployPostgreSql && postgreSqlNetworkIsolation) {
   name: postgreSqlPrivateDnsZoneName
   location: 'global'
   tags: deploymentTags
 }
 
-resource postgreSqlPrivateDnsZoneVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = if (deployPostgreSql && postgreSqlNetworkIsolation && deployPostgreSqlPrivateDnsLink) {
+resource postgreSqlPrivateDnsZoneVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (deployPostgreSql && postgreSqlNetworkIsolation && deployPostgreSqlPrivateDnsLink) {
   name: effectivePostgreSqlPrivateDnsLinkName
   parent: postgreSqlPrivateDnsZone
   location: 'global'
@@ -428,11 +428,11 @@ module postgreSqlFlexibleServer 'br/public:avm/res/db-for-postgre-sql/flexible-s
   }
 }
 
-resource postgreSqlFlexibleServerResource 'Microsoft.DBforPostgreSQL/flexibleServers@2025-06-01-preview' existing = if (deployPostgreSql) {
+resource postgreSqlFlexibleServerResource 'Microsoft.DBforPostgreSQL/flexibleServers@2025-08-01' existing = if (deployPostgreSql) {
   name: postgreSqlServerName
 }
 
-resource postgreSqlAllowAzureServicesFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2025-01-01-preview' = if (deployPostgreSql && !postgreSqlNetworkIsolation && postgreSqlAllowAzureServices) {
+resource postgreSqlAllowAzureServicesFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2025-08-01' = if (deployPostgreSql && !postgreSqlNetworkIsolation && postgreSqlAllowAzureServices) {
   parent: postgreSqlFlexibleServerResource
   name: 'AllowAzureServices'
   properties: {
@@ -444,7 +444,7 @@ resource postgreSqlAllowAzureServicesFirewallRule 'Microsoft.DBforPostgreSQL/fle
   ]
 }
 
-resource postgreSqlAdminSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (deployPostgreSql && enablePostgreSqlKeyVaultSecret) {
+resource postgreSqlAdminSecret 'Microsoft.KeyVault/vaults/secrets@2026-02-01' = if (deployPostgreSql && enablePostgreSqlKeyVaultSecret) {
   name: postgreSqlAdminSecretName
   parent: keyVault
   properties: {

--- a/infra/main.json
+++ b/infra/main.json
@@ -1,0 +1,5358 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.42.1.51946",
+      "templateHash": "10203842773715246176"
+    },
+    "description": "Deploys AI Landing Zone with Fabric capacity extension"
+  },
+  "definitions": {
+    "_1.workloadProfileInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Friendly name of the workload profile."
+          }
+        },
+        "workloadProfileType": {
+          "type": "string",
+          "allowedValues": [
+            "Consumption",
+            "D16",
+            "D32",
+            "D4",
+            "D8",
+            "E16",
+            "E32",
+            "E4",
+            "E8",
+            "NC24-A100",
+            "NC48-A100",
+            "NC96-A100"
+          ],
+          "metadata": {
+            "description": "Type of the workload profile."
+          }
+        },
+        "minimumCount": {
+          "type": "int",
+          "nullable": false,
+          "metadata": {
+            "description": "Minimum number of nodes for the workload profile."
+          }
+        },
+        "maximumCount": {
+          "type": "int",
+          "nullable": false,
+          "metadata": {
+            "description": "Maximum number of nodes for the workload profile."
+          }
+        }
+      },
+      "metadata": {
+        "description": "Information about a workload profile for the environment.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "../submodules/ai-landing-zone/constants/constants.bicep"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "environmentName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Developer CLI environment."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for resources."
+      }
+    },
+    "cosmosLocation": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for Cosmos DB."
+      }
+    },
+    "principalId": {
+      "type": "string",
+      "defaultValue": "[deployer().objectId]",
+      "metadata": {
+        "description": "Principal ID for role assignments."
+      }
+    },
+    "principalType": {
+      "type": "string",
+      "defaultValue": "User",
+      "allowedValues": [
+        "User",
+        "ServicePrincipal",
+        "Group"
+      ],
+      "metadata": {
+        "description": "Principal type for role assignments."
+      }
+    },
+    "deploymentTags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Tags for all resources."
+      }
+    },
+    "appConfigLabel": {
+      "type": "string",
+      "defaultValue": "ai-lz",
+      "metadata": {
+        "description": "App Configuration label."
+      }
+    },
+    "networkIsolation": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable network isolation."
+      }
+    },
+    "useExistingVNet": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Use an existing VNet."
+      }
+    },
+    "existingVnetResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Existing VNet resource ID."
+      }
+    },
+    "agentSubnetName": {
+      "type": "string",
+      "defaultValue": "agent-subnet",
+      "metadata": {
+        "description": "Subnet names."
+      }
+    },
+    "peSubnetName": {
+      "type": "string",
+      "defaultValue": "pe-subnet"
+    },
+    "gatewaySubnetName": {
+      "type": "string",
+      "defaultValue": "gateway-subnet"
+    },
+    "azureBastionSubnetName": {
+      "type": "string",
+      "defaultValue": "AzureBastionSubnet"
+    },
+    "azureFirewallSubnetName": {
+      "type": "string",
+      "defaultValue": "AzureFirewallSubnet"
+    },
+    "azureAppGatewaySubnetName": {
+      "type": "string",
+      "defaultValue": "AppGatewaySubnet"
+    },
+    "jumpboxSubnetName": {
+      "type": "string",
+      "defaultValue": "jumpbox-subnet"
+    },
+    "apiManagementSubnetName": {
+      "type": "string",
+      "defaultValue": "api-management-subnet"
+    },
+    "acaEnvironmentSubnetName": {
+      "type": "string",
+      "defaultValue": "aca-environment-subnet"
+    },
+    "devopsBuildAgentsSubnetName": {
+      "type": "string",
+      "defaultValue": "devops-build-agents-subnet"
+    },
+    "vnetAddressPrefixes": {
+      "type": "array",
+      "defaultValue": [
+        "192.168.0.0/21"
+      ],
+      "metadata": {
+        "description": "VNet address prefixes."
+      }
+    },
+    "agentSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.0.0/24",
+      "metadata": {
+        "description": "Subnet address prefixes."
+      }
+    },
+    "acaEnvironmentSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.1.0/24"
+    },
+    "peSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.2.0/26"
+    },
+    "azureBastionSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.2.64/26"
+    },
+    "azureFirewallSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.2.128/26"
+    },
+    "gatewaySubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.2.192/26"
+    },
+    "azureAppGatewaySubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.3.0/27"
+    },
+    "apimSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.3.32/27"
+    },
+    "jumpboxSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.3.64/27"
+    },
+    "devopsBuildAgentsSubnetPrefix": {
+      "type": "string",
+      "defaultValue": "192.168.3.96/27"
+    },
+    "deployGroundingWithBing": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Feature flags."
+      }
+    },
+    "deployAiFoundry": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployAiFoundrySubnet": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployAppConfig": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployKeyVault": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployVmKeyVault": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployLogAnalytics": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "deployAppInsights": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deploySearchService": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployStorageAccount": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployCosmosDb": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployContainerApps": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployContainerRegistry": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployContainerEnv": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployVM": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deploySubnets": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployNsgs": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "sideBySideDeploy": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deploySoftware": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployApim": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "deployAfProject": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "deployAAfAgentSvc": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "enableAgenticRetrieval": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "aiSearchResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Existing resource IDs to reuse."
+      }
+    },
+    "aiSearchAdditionalAccessObjectIds": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional additional Entra object IDs to grant Search roles."
+      }
+    },
+    "aiFoundryStorageAccountResourceId": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "aiFoundryCosmosDBAccountResourceId": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "keyVaultResourceId": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "useUAI": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Identity options."
+      }
+    },
+    "useCAppAPIKey": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "useZoneRedundancy": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "resourceToken": {
+      "type": "string",
+      "defaultValue": "[toLower(uniqueString(subscription().id, parameters('environmentName'), parameters('location')))]",
+      "metadata": {
+        "description": "Resource naming token."
+      }
+    },
+    "baseName": {
+      "type": "string",
+      "defaultValue": "[substring(parameters('resourceToken'), 0, 12)]",
+      "metadata": {
+        "description": "Short base name for resource naming."
+      }
+    },
+    "aiFoundryAccountName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').ai.aiFoundry, parameters('resourceToken'))]",
+      "metadata": {
+        "description": "Resource names."
+      }
+    },
+    "aiFoundryProjectName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').ai.aiFoundryProject, parameters('resourceToken'))]"
+    },
+    "aiFoundryStorageAccountName": {
+      "type": "string",
+      "defaultValue": "[replace(format('{0}{1}{2}', variables('_1.abbrs').storage.storageAccount, variables('_1.abbrs').ai.aiFoundry, parameters('resourceToken')), '-', '')]"
+    },
+    "aiFoundrySearchServiceName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}{2}', variables('_1.abbrs').ai.aiSearch, variables('_1.abbrs').ai.aiFoundry, parameters('resourceToken'))]"
+    },
+    "aiFoundryCosmosDbName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}{2}', variables('_1.abbrs').databases.cosmosDBDatabase, variables('_1.abbrs').ai.aiFoundry, parameters('resourceToken'))]"
+    },
+    "bingSearchName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').ai.bing, parameters('resourceToken'))]"
+    },
+    "appConfigName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').configuration.appConfiguration, parameters('resourceToken'))]"
+    },
+    "appInsightsName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').managementGovernance.applicationInsights, parameters('resourceToken'))]"
+    },
+    "containerEnvName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').containers.containerAppsEnvironment, parameters('resourceToken'))]"
+    },
+    "containerRegistryName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').containers.containerRegistry, parameters('resourceToken'))]"
+    },
+    "dbAccountName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').databases.cosmosDBDatabase, parameters('resourceToken'))]"
+    },
+    "dbDatabaseName": {
+      "type": "string",
+      "defaultValue": "[format('{0}db{1}', variables('_1.abbrs').databases.cosmosDBDatabase, parameters('resourceToken'))]"
+    },
+    "keyVaultName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').security.keyVault, parameters('resourceToken'))]"
+    },
+    "logAnalyticsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').managementGovernance.logAnalyticsWorkspace, parameters('resourceToken'))]"
+    },
+    "searchServiceName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').ai.aiSearch, parameters('resourceToken'))]"
+    },
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').storage.storageAccount, parameters('resourceToken'))]"
+    },
+    "vnetName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', variables('_1.abbrs').networking.virtualNetwork, parameters('resourceToken'))]"
+    },
+    "modelDeploymentList": {
+      "type": "array",
+      "metadata": {
+        "description": "Model deployments and container app configuration."
+      }
+    },
+    "containerAppsList": {
+      "type": "array"
+    },
+    "workloadProfiles": {
+      "type": "array",
+      "defaultValue": []
+    },
+    "acrDnsSuffix": {
+      "type": "string",
+      "defaultValue": "[if(equals(environment().name, 'AzureUSGovernment'), 'azurecr.us', if(equals(environment().name, 'AzureChinaCloud'), 'azurecr.cn', 'azurecr.io'))]",
+      "metadata": {
+        "description": "Miscellaneous settings."
+      }
+    },
+    "databaseContainersList": {
+      "type": "array"
+    },
+    "vmName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "vmUserName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "vmAdminPassword": {
+      "type": "securestring"
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D8s_v5"
+    },
+    "vmImageSku": {
+      "type": "string",
+      "defaultValue": "win11-25h2-ent"
+    },
+    "vmImagePublisher": {
+      "type": "string",
+      "defaultValue": "MicrosoftWindowsDesktop"
+    },
+    "vmImageOffer": {
+      "type": "string",
+      "defaultValue": "windows-11"
+    },
+    "vmImageVersion": {
+      "type": "string",
+      "defaultValue": "latest"
+    },
+    "storageAccountContainersList": {
+      "type": "array"
+    },
+    "deployFabricCapacity": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Deploy Fabric capacity"
+      }
+    },
+    "fabricCapacityMode": {
+      "type": "string",
+      "defaultValue": "[if(parameters('deployFabricCapacity'), 'create', 'none')]",
+      "allowedValues": [
+        "create",
+        "byo",
+        "none"
+      ],
+      "metadata": {
+        "description": "Fabric capacity mode. Use create to provision a capacity, byo to reuse an existing capacity, or none to disable Fabric capacity."
+      }
+    },
+    "fabricCapacityResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Existing Fabric capacity resource ID (required when fabricCapacityMode=byo)."
+      }
+    },
+    "fabricWorkspaceMode": {
+      "type": "string",
+      "defaultValue": "[if(equals(parameters('fabricCapacityMode'), 'none'), 'none', 'create')]",
+      "allowedValues": [
+        "create",
+        "byo",
+        "none"
+      ],
+      "metadata": {
+        "description": "Fabric workspace mode. Use create to create a workspace in postprovision, byo to reuse an existing workspace, or none to disable Fabric workspace automation."
+      }
+    },
+    "fabricWorkspaceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Existing Fabric workspace ID (GUID) (required when fabricWorkspaceMode=byo)."
+      }
+    },
+    "fabricWorkspaceName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Existing Fabric workspace name (used when fabricWorkspaceMode=byo)."
+      }
+    },
+    "fabricCapacitySku": {
+      "type": "string",
+      "defaultValue": "F8",
+      "allowedValues": [
+        "F2",
+        "F4",
+        "F8",
+        "F16",
+        "F32",
+        "F64",
+        "F128",
+        "F256",
+        "F512",
+        "F1024",
+        "F2048"
+      ],
+      "metadata": {
+        "description": "Fabric capacity SKU"
+      }
+    },
+    "fabricCapacityAdmins": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Fabric capacity admin members"
+      }
+    },
+    "purviewAccountResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Existing Purview account resource ID"
+      }
+    },
+    "purviewCollectionName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Existing Purview collection name"
+      }
+    },
+    "createdBy": {
+      "type": "string",
+      "defaultValue": "[if(contains(deployer(), 'userPrincipalName'), split(deployer().userPrincipalName, '@')[0], deployer().objectId)]",
+      "metadata": {
+        "description": "Optional. Created by user name."
+      }
+    },
+    "deployPostgreSql": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Deploy PostgreSQL Flexible Server."
+      }
+    },
+    "postgreSqlServerName": {
+      "type": "string",
+      "defaultValue": "[format('pg{0}', parameters('resourceToken'))]",
+      "metadata": {
+        "description": "PostgreSQL Flexible Server name."
+      }
+    },
+    "postgreSqlNetworkIsolation": {
+      "type": "bool",
+      "defaultValue": "[parameters('networkIsolation')]",
+      "metadata": {
+        "description": "Enable network isolation for PostgreSQL (private DNS + private endpoint)."
+      }
+    },
+    "postgreSqlAllowAzureServices": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Allow connections from Azure services to the PostgreSQL server when public access is enabled. This creates the 0.0.0.0 firewall rule equivalent to the portal Allow Azure services setting."
+      }
+    },
+    "deployPostgreSqlPrivateDnsLink": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Create and link the PostgreSQL private DNS zone to the VNet."
+      }
+    },
+    "postgreSqlPrivateDnsLinkNameOverride": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional override for the PostgreSQL private DNS VNet link name."
+      }
+    },
+    "postgreSqlAdminLogin": {
+      "type": "string",
+      "defaultValue": "pgadmin",
+      "metadata": {
+        "description": "PostgreSQL admin username."
+      }
+    },
+    "postgreSqlAdminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "PostgreSQL admin password."
+      }
+    },
+    "enablePostgreSqlKeyVaultSecret": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Store PostgreSQL admin password in Key Vault."
+      }
+    },
+    "postgreSqlAdminSecretName": {
+      "type": "string",
+      "defaultValue": "postgres-admin-password",
+      "metadata": {
+        "description": "Key Vault secret name for PostgreSQL admin password."
+      }
+    },
+    "postgreSqlFabricUserName": {
+      "type": "string",
+      "defaultValue": "fabric_user",
+      "metadata": {
+        "description": "PostgreSQL role name for Fabric mirroring."
+      }
+    },
+    "postgreSqlFabricUserSecretName": {
+      "type": "string",
+      "defaultValue": "postgres-fabric-user-password",
+      "metadata": {
+        "description": "Key Vault secret name for the Fabric mirroring PostgreSQL role password."
+      }
+    },
+    "postgreSqlMirrorConnectionMode": {
+      "type": "string",
+      "defaultValue": "fabricUser",
+      "allowedValues": [
+        "fabricUser",
+        "admin"
+      ],
+      "metadata": {
+        "description": "Credential mode used for the Fabric PostgreSQL connection. Use fabricUser for the production-oriented least-privilege path or admin for a simplified demo automation path."
+      }
+    },
+    "postgreSqlAuthConfig": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.DBforPostgreSQL/flexibleServers@2025-08-01#properties/properties/properties/authConfig"
+        },
+        "description": "Authentication configuration for PostgreSQL Flexible Server. Defaults to both Microsoft Entra and password authentication enabled so Fabric mirroring can be configured immediately after deployment."
+      },
+      "defaultValue": {
+        "activeDirectoryAuth": "Enabled",
+        "passwordAuth": "Enabled"
+      }
+    },
+    "postgreSqlSkuName": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "PostgreSQL SKU name (tier + family + cores)."
+      }
+    },
+    "postgreSqlTier": {
+      "type": "string",
+      "defaultValue": "GeneralPurpose",
+      "allowedValues": [
+        "Burstable",
+        "GeneralPurpose",
+        "MemoryOptimized"
+      ],
+      "metadata": {
+        "description": "PostgreSQL tier aligned with SKU."
+      }
+    },
+    "postgreSqlAvailabilityZone": {
+      "type": "int",
+      "defaultValue": -1,
+      "allowedValues": [
+        -1,
+        1,
+        2,
+        3
+      ],
+      "metadata": {
+        "description": "PostgreSQL availability zone. -1 means no zone preference."
+      }
+    },
+    "postgreSqlHighAvailability": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "allowedValues": [
+        "Disabled",
+        "SameZone",
+        "ZoneRedundant"
+      ],
+      "metadata": {
+        "description": "PostgreSQL high availability mode."
+      }
+    },
+    "postgreSqlHighAvailabilityZone": {
+      "type": "int",
+      "defaultValue": -1,
+      "allowedValues": [
+        -1,
+        1,
+        2,
+        3
+      ],
+      "metadata": {
+        "description": "PostgreSQL high availability standby zone. -1 means no zone preference."
+      }
+    },
+    "postgreSqlVersion": {
+      "type": "string",
+      "defaultValue": "16",
+      "allowedValues": [
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18"
+      ],
+      "metadata": {
+        "description": "PostgreSQL version."
+      }
+    },
+    "postgreSqlStorageSizeGB": {
+      "type": "int",
+      "defaultValue": 32,
+      "metadata": {
+        "description": "PostgreSQL storage size in GB."
+      }
+    },
+    "generatedPostgreSqlAdminPassword": {
+      "type": "securestring",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "Generated value used when postgreSqlAdminPassword is left as the placeholder token."
+      }
+    }
+  },
+  "variables": {
+    "effectiveFabricCapacityMode": "[parameters('fabricCapacityMode')]",
+    "effectiveFabricWorkspaceMode": "[parameters('fabricWorkspaceMode')]",
+    "effectiveLocation": "[if(not(empty(parameters('location'))), parameters('location'), resourceGroup().location)]",
+    "envSlugSanitized": "[replace(replace(replace(replace(replace(replace(replace(replace(toLower(parameters('environmentName')), ' ', ''), '-', ''), '_', ''), '.', ''), '/', ''), '\\', ''), ':', ''), ',', '')]",
+    "envSlugTrimmed": "[substring(variables('envSlugSanitized'), 0, min(40, length(variables('envSlugSanitized'))))]",
+    "capacityNameBase": "[if(not(empty(variables('envSlugTrimmed'))), format('fabric{0}', variables('envSlugTrimmed')), format('fabric{0}', parameters('baseName')))]",
+    "capacityName": "[substring(variables('capacityNameBase'), 0, min(50, length(variables('capacityNameBase'))))]",
+    "effectiveVnetResourceId": "[if(and(parameters('useExistingVNet'), not(empty(parameters('existingVnetResourceId')))), parameters('existingVnetResourceId'), resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName')))]",
+    "postgreSqlPrivateDnsZoneName": "privatelink.postgres.database.azure.com",
+    "postgreSqlPrivateDnsLinkNameRaw": "[format('{0}-vnetlink', parameters('postgreSqlServerName'))]",
+    "postgreSqlPrivateEndpointNameRaw": "[format('{0}-pe', parameters('postgreSqlServerName'))]",
+    "postgreSqlPrivateDnsLinkName": "[substring(variables('postgreSqlPrivateDnsLinkNameRaw'), 0, min(80, length(variables('postgreSqlPrivateDnsLinkNameRaw'))))]",
+    "effectivePostgreSqlPrivateDnsLinkName": "[if(not(empty(parameters('postgreSqlPrivateDnsLinkNameOverride'))), parameters('postgreSqlPrivateDnsLinkNameOverride'), variables('postgreSqlPrivateDnsLinkName'))]",
+    "postgreSqlPrivateEndpointName": "[substring(variables('postgreSqlPrivateEndpointNameRaw'), 0, min(80, length(variables('postgreSqlPrivateEndpointNameRaw'))))]",
+    "effectiveKeyVaultResourceId": "[if(not(empty(parameters('keyVaultResourceId'))), parameters('keyVaultResourceId'), resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')))]",
+    "effectivePostgreSqlAdminPassword": "[if(equals(parameters('postgreSqlAdminPassword'), '$(secretOrRandomPassword)'), format('{0}!{1}', uniqueString(subscription().id, resourceGroup().id, parameters('postgreSqlServerName')), replace(parameters('generatedPostgreSqlAdminPassword'), '-', '')), parameters('postgreSqlAdminPassword'))]",
+    "postgreSqlPrivateEndpoints": "[if(parameters('postgreSqlNetworkIsolation'), createArray(createObject('name', variables('postgreSqlPrivateEndpointName'), 'subnetResourceId', format('{0}/subnets/{1}', variables('effectiveVnetResourceId'), parameters('peSubnetName')), 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('privateDnsZoneResourceId', resourceId('Microsoft.Network/privateDnsZones', variables('postgreSqlPrivateDnsZoneName'))))))), createArray())]",
+    "effectiveAiSearchResourceId": "[if(not(empty(parameters('aiSearchResourceId'))), parameters('aiSearchResourceId'), resourceId('Microsoft.Search/searchServices', parameters('searchServiceName')))]",
+    "effectiveStorageAccountResourceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+    "effectiveFabricWorkspaceName": "[if(equals(variables('effectiveFabricWorkspaceMode'), 'byo'), if(not(empty(parameters('fabricWorkspaceName'))), parameters('fabricWorkspaceName'), if(not(empty(parameters('environmentName'))), format('workspace-{0}', parameters('environmentName')), format('workspace-{0}', parameters('baseName')))), if(not(empty(parameters('environmentName'))), format('workspace-{0}', parameters('environmentName')), format('workspace-{0}', parameters('baseName'))))]",
+    "effectiveFabricWorkspaceId": "[if(equals(variables('effectiveFabricWorkspaceMode'), 'byo'), parameters('fabricWorkspaceId'), '')]",
+    "_1._2": {
+      "ai": {
+        "aiFoundry": "aif-",
+        "aiFoundryProject": "aifp-",
+        "aiSearch": "srch-",
+        "aiServices": "aisa-",
+        "aiVideoIndexer": "avi-",
+        "bing": "bing-",
+        "machineLearningWorkspace": "mlw-",
+        "openAIService": "oai-",
+        "botService": "bot-",
+        "computerVision": "cv-",
+        "contentModerator": "cm-",
+        "contentSafety": "cs-",
+        "customVisionPrediction": "cstv-",
+        "customVisionTraining": "cstvt-",
+        "documentIntelligence": "di-",
+        "faceApi": "face-",
+        "healthInsights": "hi-",
+        "immersiveReader": "ir-",
+        "languageService": "lang-",
+        "speechService": "spch-",
+        "translator": "trsl-",
+        "aiHub": "aih-",
+        "aiHubProject": "aihp-"
+      },
+      "analytics": {
+        "analysisServicesServer": "as",
+        "databricksWorkspace": "dbw-",
+        "dataExplorerCluster": "dec",
+        "dataExplorerClusterDatabase": "dedb",
+        "dataFactory": "adf-",
+        "digitalTwin": "dt-",
+        "streamAnalytics": "asa-",
+        "synapseAnalyticsPrivateLinkHub": "synplh-",
+        "synapseAnalyticsSQLDedicatedPool": "syndp",
+        "synapseAnalyticsSparkPool": "synsp",
+        "synapseAnalyticsWorkspaces": "synw",
+        "dataLakeStoreAccount": "dls",
+        "dataLakeAnalyticsAccount": "dla",
+        "eventHubsNamespace": "evhns-",
+        "eventHub": "evh-",
+        "eventGridDomain": "evgd-",
+        "eventGridSubscriptions": "evgs-",
+        "eventGridTopic": "evgt-",
+        "eventGridSystemTopic": "egst-",
+        "hdInsightHadoopCluster": "hadoop-",
+        "hdInsightHBaseCluster": "hbase-",
+        "hdInsightKafkaCluster": "kafka-",
+        "hdInsightSparkCluster": "spark-",
+        "hdInsightStormCluster": "storm-",
+        "hdInsightMLServicesCluster": "mls-",
+        "iotHub": "iot-",
+        "provisioningServices": "provs-",
+        "provisioningServicesCertificate": "pcert-",
+        "powerBIEmbedded": "pbi-",
+        "timeSeriesInsightsEnvironment": "tsi-"
+      },
+      "configuration": {
+        "appConfiguration": "appcs-"
+      },
+      "compute": {
+        "appServiceEnvironment": "ase-",
+        "appServicePlan": "asp-",
+        "loadTesting": "lt-",
+        "availabilitySet": "avail-",
+        "arcEnabledServer": "arcs-",
+        "arcEnabledKubernetesCluster": "arck",
+        "batchAccounts": "ba-",
+        "cloudService": "cld-",
+        "communicationServices": "acs-",
+        "diskEncryptionSet": "des",
+        "functionApp": "func-",
+        "gallery": "gal",
+        "hostingEnvironment": "host-",
+        "imageTemplate": "it-",
+        "managedDiskOS": "osdisk",
+        "managedDiskData": "disk",
+        "notificationHubs": "ntf-",
+        "notificationHubsNamespace": "ntfns-",
+        "proximityPlacementGroup": "ppg-",
+        "restorePointCollection": "rpc-",
+        "snapshot": "snap-",
+        "staticWebApp": "stapp-",
+        "virtualMachine": "vm-",
+        "virtualMachineScaleSet": "vmss-",
+        "virtualMachineMaintenanceConfiguration": "mc-",
+        "virtualMachineStorageAccount": "stvm",
+        "webApp": "app-"
+      },
+      "containers": {
+        "aksCluster": "aks-",
+        "aksSystemNodePool": "npsystem-",
+        "aksUserNodePool": "np-",
+        "containerApp": "ca-",
+        "containerAppsEnvironment": "cae-",
+        "containerRegistry": "cr",
+        "containerInstance": "ci",
+        "serviceFabricCluster": "sf-",
+        "serviceFabricManagedCluster": "sfmc-"
+      },
+      "databases": {
+        "cosmosDBDatabase": "cosmos-",
+        "cosmosDBApacheCassandra": "coscas-",
+        "cosmosDBMongoDB": "cosmon-",
+        "cosmosDBNoSQL": "cosno-",
+        "cosmosDBTable": "costab-",
+        "cosmosDBGremlin": "cosgrm-",
+        "cosmosDBPostgreSQL": "cospos-",
+        "cacheForRedis": "redis-",
+        "sqlDatabaseServer": "sql-",
+        "sqlDatabase": "sqldb-",
+        "sqlElasticJobAgent": "sqlja-",
+        "sqlElasticPool": "sqlep-",
+        "mariaDBServer": "maria-",
+        "mariaDBDatabase": "mariadb-",
+        "mySQLDatabase": "mysql-",
+        "postgreSQLDatabase": "psql-",
+        "sqlServerStretchDatabase": "sqlstrdb-",
+        "sqlManagedInstance": "sqlmi-"
+      },
+      "developerTools": {
+        "appConfigurationStore": "appcs-",
+        "mapsAccount": "map-",
+        "signalR": "sigr",
+        "webPubSub": "wps-"
+      },
+      "devOps": {
+        "managedGrafana": "amg-"
+      },
+      "integration": {
+        "integrationAccount": "ia-",
+        "logicApp": "logic-",
+        "serviceBusNamespace": "sbns-",
+        "serviceBusQueue": "sbq-",
+        "serviceBusTopic": "sbt-",
+        "serviceBusTopicSubscription": "sbts-"
+      },
+      "managementGovernance": {
+        "automationAccount": "aa-",
+        "applicationInsights": "appi-",
+        "grafana": "graf-",
+        "monitorActionGroup": "ag-",
+        "monitorDataCollectionRules": "dcr-",
+        "monitorAlertProcessingRule": "apr-",
+        "blueprint": "bp-",
+        "blueprintAssignment": "bpa-",
+        "dataCollectionEndpoint": "dce-",
+        "logAnalyticsWorkspace": "log-",
+        "logAnalyticsQueryPacks": "pack-",
+        "managementGroup": "mg-",
+        "purviewInstance": "pview-",
+        "resourceGroup": "rg-",
+        "templateSpecsName": "ts-"
+      },
+      "migration": {
+        "migrateProject": "migr-",
+        "databaseMigrationService": "dms-",
+        "recoveryServicesVault": "rsv-"
+      },
+      "networking": {
+        "aivnet": "aivnet-",
+        "applicationGateway": "agw-",
+        "applicationSecurityGroup": "asg-",
+        "cdnProfile": "cdnp-",
+        "cdnEndpoint": "cdne-",
+        "connections": "con-",
+        "dnsForwardingRuleset": "dnsfrs-",
+        "dnsPrivateResolver": "dnspr-",
+        "dnsPrivateResolverInboundEndpoint": "in-",
+        "dnsPrivateResolverOutboundEndpoint": "out-",
+        "firewall": "afw-",
+        "firewallPolicy": "afwp-",
+        "expressRouteCircuit": "erc-",
+        "expressRouteGateway": "ergw-",
+        "frontDoorProfile": "afd-",
+        "frontDoorEndpoint": "fde-",
+        "frontDoorFirewallPolicy": "fdfp-",
+        "ipGroups": "ipg-",
+        "loadBalancerInternal": "lbi-",
+        "loadBalancerExternal": "lbe-",
+        "loadBalancerRule": "rule-",
+        "localNetworkGateway": "lgw-",
+        "natGateway": "ng-",
+        "networkInterface": "nic-",
+        "networkSecurityGroup": "nsg-",
+        "networkSecurityGroupSecurityRules": "nsgsr-",
+        "networkWatcher": "nw-",
+        "privateLink": "pl-",
+        "privateLinkScope": "pls-",
+        "privateEndpoint": "pep-",
+        "publicIPAddress": "pip-",
+        "publicIPAddressPrefix": "ippre-",
+        "routeFilter": "rf-",
+        "routeServer": "rtserv-",
+        "routeTable": "rt-",
+        "serviceEndpointPolicy": "se-",
+        "trafficManagerProfile": "traf-",
+        "userDefinedRoute": "udr-",
+        "virtualNetwork": "vnet-",
+        "virtualNetworkGateway": "vgw-",
+        "virtualNetworkManager": "vnm-",
+        "virtualNetworkPeering": "peer-",
+        "virtualNetworkSubnet": "snet-",
+        "virtualWAN": "vwan-",
+        "virtualWANHub": "vhub-"
+      },
+      "security": {
+        "bastion": "bas-",
+        "keyVault": "kv-",
+        "privateEndpoint": "pe-",
+        "keyVaultManagedHSM": "kvmhsm-",
+        "managedIdentity": "uai-",
+        "sshKey": "sshkey-",
+        "vpnGateway": "vpng-",
+        "vpnConnection": "vcn-",
+        "vpnSite": "vst-",
+        "webApplicationFirewallPolicy": "waf",
+        "webApplicationFirewallPolicyRuleGroup": "wafrg"
+      },
+      "storage": {
+        "storSimple": "ssimp",
+        "backupVault": "bvault-",
+        "backupVaultPolicy": "bkpol-",
+        "fileShare": "share-",
+        "storageAccount": "st",
+        "storageSyncService": "sss-"
+      },
+      "virtualDesktop": {
+        "labServicesPlan": "lp-",
+        "virtualDesktopHostPool": "vdpool-",
+        "virtualDesktopApplicationGroup": "vdag-",
+        "virtualDesktopWorkspace": "vdws-",
+        "virtualDesktopScalingPlan": "vdscaling-"
+      }
+    },
+    "_1._3": {
+      "AcrDelete": {
+        "guid": "c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+        "key": "AcrDelete"
+      },
+      "AcrImageSigner": {
+        "guid": "6cef56e8-d556-48e5-a04f-b8e64114680f",
+        "key": "AcrImageSigner"
+      },
+      "AcrPull": {
+        "guid": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+        "key": "AcrPull"
+      },
+      "AcrPush": {
+        "guid": "8311e382-0749-4cb8-b61a-304f252e45ec",
+        "key": "AcrPush"
+      },
+      "AcrQuarantineReader": {
+        "guid": "cdda3590-29a3-44f6-95f2-9f980659eb04",
+        "key": "AcrQuarantineReader"
+      },
+      "AcrQuarantineWriter": {
+        "guid": "c8d4ff99-41c3-41a8-9f60-21dfdad59608",
+        "key": "AcrQuarantineWriter"
+      },
+      "AksClusterAdminRole": {
+        "guid": "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
+        "key": "AksClusterAdminRole"
+      },
+      "AksClusterMonitoringUser": {
+        "guid": "1afdec4b-e479-420e-99e7-f82237c7c5e6",
+        "key": "AksClusterMonitoringUser"
+      },
+      "AksClusterUserRole": {
+        "guid": "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
+        "key": "AksClusterUserRole"
+      },
+      "AksContributorRole": {
+        "guid": "ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8",
+        "key": "AksContributorRole"
+      },
+      "AksFleetManagerContributorRole": {
+        "guid": "63bb64ad-9799-4770-b5c3-24ed299a07bf",
+        "key": "AksFleetManagerContributorRole"
+      },
+      "AksFleetManagerRBACAdmin": {
+        "guid": "434fb43a-c01c-447e-9f67-c3ad923cfaba",
+        "key": "AksFleetManagerRBACAdmin"
+      },
+      "AksFleetManagerRBACClusterAdmin": {
+        "guid": "18ab4d3d-a1bf-4477-8ad9-8359bc988f69",
+        "key": "AksFleetManagerRBACClusterAdmin"
+      },
+      "AksFleetManagerRBACReader": {
+        "guid": "30b27cfc-9c84-438e-b0ce-70e35255df80",
+        "key": "AksFleetManagerRBACReader"
+      },
+      "AksFleetManagerRBACWriter": {
+        "guid": "5af6afb3-c06c-4fa4-8848-71a8aee05683",
+        "key": "AksFleetManagerRBACWriter"
+      },
+      "AksRBACAdmin": {
+        "guid": "3498e952-d568-435e-9b2c-8d77e338d7f7",
+        "key": "AksRBACAdmin"
+      },
+      "AksRBACClusterAdmin": {
+        "guid": "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
+        "key": "AksRBACClusterAdmin"
+      },
+      "AksRBACReader": {
+        "guid": "7f6c6a51-bcf8-42ba-9220-52d62157d7db",
+        "key": "AksRBACReader"
+      },
+      "AksRBACWriter": {
+        "guid": "a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb",
+        "key": "AksRBACWriter"
+      },
+      "AppComplianceAutomationAdministrator": {
+        "guid": "0f37683f-2463-46b6-9ce7-9b788b988ba2",
+        "key": "AppComplianceAutomationAdministrator"
+      },
+      "AppComplianceAutomationReader": {
+        "guid": "ffc6bbe0-e443-4c3b-bf54-26581bb2f78e",
+        "key": "AppComplianceAutomationReader"
+      },
+      "AppConfigurationDataOwner": {
+        "guid": "5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b",
+        "key": "AppConfigurationDataOwner"
+      },
+      "AppConfigurationDataReader": {
+        "guid": "516239f1-63e1-4d78-a4de-a74fb236a071",
+        "key": "AppConfigurationDataReader"
+      },
+      "ApplicationInsightsComponentContributor": {
+        "guid": "ae349356-3a1b-4a5e-921d-050484c6347e",
+        "key": "ApplicationInsightsComponentContributor"
+      },
+      "ApplicationInsightsSnapshotDebugger": {
+        "guid": "08954f03-6346-4c2e-81c0-ec3a5cfae23b",
+        "key": "ApplicationInsightsSnapshotDebugger"
+      },
+      "AttestationContributor": {
+        "guid": "bbf86eb8-f7b4-4cce-96e4-18cddf81d86e",
+        "key": "AttestationContributor"
+      },
+      "AttestationReader": {
+        "guid": "fd1bd22b-8476-40bc-a0bc-69b95687b9f3",
+        "key": "AttestationReader"
+      },
+      "AutomationContributor": {
+        "guid": "f353d9bd-d4a6-484e-a77a-8050b599b867",
+        "key": "AutomationContributor"
+      },
+      "AutomationJobOperator": {
+        "guid": "4fe576fe-1146-4730-92eb-48519fa6bf9f",
+        "key": "AutomationJobOperator"
+      },
+      "AutomationOperator": {
+        "guid": "d3881f73-407a-4167-8283-e981cbba0404",
+        "key": "AutomationOperator"
+      },
+      "AutomationRunbookOperator": {
+        "guid": "5fb5aef8-1081-4b8e-bb16-9d5d0385bab5",
+        "key": "AutomationRunbookOperator"
+      },
+      "AvereContributor": {
+        "guid": "4f8fab4f-1852-4a58-a46a-8eaf358af14a",
+        "key": "AvereContributor"
+      },
+      "AvereOperator": {
+        "guid": "c025889f-8102-4ebf-b32c-fc0c6f0c6bd9",
+        "key": "AvereOperator"
+      },
+      "AzureAIAdministrator": {
+        "guid": "b78c5d69-af96-48a3-bf8d-a8b4d589de94",
+        "key": "AzureAIAdministrator"
+      },
+      "AzureAIDeveloper": {
+        "guid": "64702f94-c441-49e6-a78b-ef80e0188fee",
+        "key": "AzureAIDeveloper"
+      },
+      "AzureAIEnterpriseNetworkConnectionApprover": {
+        "guid": "b556d68e-0be0-4f35-a333-ad7ee1ce17ea",
+        "key": "AzureAIEnterpriseNetworkConnectionApprover"
+      },
+      "AzureAIInferenceDeploymentOperator": {
+        "guid": "3afb7f49-54cb-416e-8c09-6dc049efa503",
+        "key": "AzureAIInferenceDeploymentOperator"
+      },
+      "AzureAIProjectManager": {
+        "guid": "eadc314b-1a2d-4efa-be10-5d325db5065e",
+        "key": "AzureAIProjectManager"
+      },
+      "AzureAISafetyEvaluator": {
+        "guid": "11102f94-c441-49e6-a78b-ef80e0188abc",
+        "key": "AzureAISafetyEvaluator"
+      },
+      "AzureAIUser": {
+        "guid": "53ca6127-db72-4b80-b1b0-d745d6d5456d",
+        "key": "AzureAIUser"
+      },
+      "AzureApiCenterComplianceManager": {
+        "guid": "ede9aaa3-4627-494e-be13-4aa7c256148d",
+        "key": "AzureApiCenterComplianceManager"
+      },
+      "AzureApiCenterDataReader": {
+        "guid": "c7244dfb-f447-457d-b2ba-3999044d1706",
+        "key": "AzureApiCenterDataReader"
+      },
+      "AzureApiCenterServiceContributor": {
+        "guid": "dd24193f-ef65-44e5-8a7e-6fa6e03f7713",
+        "key": "AzureApiCenterServiceContributor"
+      },
+      "AzureApiCenterServiceReader": {
+        "guid": "6cba8790-29c5-48e5-bab1-c7541b01cb04",
+        "key": "AzureApiCenterServiceReader"
+      },
+      "AzureArcEnabledKubernetesClusterUser": {
+        "guid": "00493d72-78f6-4148-b6c5-d3ce8e4799dd",
+        "key": "AzureArcEnabledKubernetesClusterUser"
+      },
+      "AzureArcKubernetesAdmin": {
+        "guid": "dffb1e0c-446f-4dde-a09f-99eb5cc68b96",
+        "key": "AzureArcKubernetesAdmin"
+      },
+      "AzureArcKubernetesClusterAdmin": {
+        "guid": "8393591c-06b9-48a2-a542-1bd6b377f6a2",
+        "key": "AzureArcKubernetesClusterAdmin"
+      },
+      "AzureArcKubernetesViewer": {
+        "guid": "63f0a09d-1495-4db4-a681-037d84835eb4",
+        "key": "AzureArcKubernetesViewer"
+      },
+      "AzureArcKubernetesWriter": {
+        "guid": "5b999177-9696-4545-85c7-50de3797e5a1",
+        "key": "AzureArcKubernetesWriter"
+      },
+      "AzureConnectedMachineOnboarding": {
+        "guid": "b64e21ea-ac4e-4cdf-9dc9-5b892992bee7",
+        "key": "AzureConnectedMachineOnboarding"
+      },
+      "AzureConnectedMachineResourceAdministrator": {
+        "guid": "cd570a14-e51a-42ad-bac8-bafd67325302",
+        "key": "AzureConnectedMachineResourceAdministrator"
+      },
+      "AzureConnectedMachineResourceManager": {
+        "guid": "f5819b54-e033-4d82-ac66-4fec3cbf3f4c",
+        "key": "AzureConnectedMachineResourceManager"
+      },
+      "AzureConnectedSQLServerOnboarding": {
+        "guid": "e8113dce-c529-4d33-91fa-e9b972617508",
+        "key": "AzureConnectedSQLServerOnboarding"
+      },
+      "AzureContainerStorageOperator": {
+        "guid": "08d4c71a-cc63-4ce4-a9c8-5dd251b4d619",
+        "key": "AzureContainerStorageOperator"
+      },
+      "AzureContainerStorageOwner": {
+        "guid": "95de85bd-744d-4664-9dde-11430bc34793",
+        "key": "AzureContainerStorageOwner"
+      },
+      "AzureDigitalTwinsDataOwner": {
+        "guid": "bcd981a7-7f74-457b-83e1-cceb9e632ffe",
+        "key": "AzureDigitalTwinsDataOwner"
+      },
+      "AzureDigitalTwinsDataReader": {
+        "guid": "d57506d4-4c8d-48b1-8587-93c323f6a5a3",
+        "key": "AzureDigitalTwinsDataReader"
+      },
+      "AzureEventHubsDataOwner": {
+        "guid": "f526a384-b230-433a-b45c-95f59c4a2dec",
+        "key": "AzureEventHubsDataOwner"
+      },
+      "AzureEventHubsDataReceiver": {
+        "guid": "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+        "key": "AzureEventHubsDataReceiver"
+      },
+      "AzureEventHubsDataSender": {
+        "guid": "2b629674-e913-4c01-ae53-ef4638d8f975",
+        "key": "AzureEventHubsDataSender"
+      },
+      "AzureFrontDoorDomainContributor": {
+        "guid": "0ab34830-df19-4f8c-b84e-aa85b8afa6e8",
+        "key": "AzureFrontDoorDomainContributor"
+      },
+      "AzureFrontDoorDomainReader": {
+        "guid": "0f99d363-226e-4dca-9920-b807cf8e1a5f",
+        "key": "AzureFrontDoorDomainReader"
+      },
+      "AzureFrontDoorProfileReader": {
+        "guid": "662802e2-50f6-46b0-aed2-e834bacc6d12",
+        "key": "AzureFrontDoorProfileReader"
+      },
+      "AzureFrontDoorSecretReader": {
+        "guid": "0db238c4-885e-4c4f-a933-aa2cef684fca",
+        "key": "AzureFrontDoorSecretReader"
+      },
+      "AzureMLComputeOperator": {
+        "guid": "e503ece1-11d0-4e8e-8e2c-7a6c3bf38815",
+        "key": "AzureMLComputeOperator"
+      },
+      "AzureMLDataScientist": {
+        "guid": "f6c7c914-8db3-469d-8ca1-694a8f32e121",
+        "key": "AzureMLDataScientist"
+      },
+      "AzureMapsDataContributor": {
+        "guid": "8f5e0ce6-4f7b-4dcf-bddf-e6f48634a204",
+        "key": "AzureMapsDataContributor"
+      },
+      "AzureMapsDataReader": {
+        "guid": "423170ca-a8f6-4b0f-8487-9e4eb8f49bfa",
+        "key": "AzureMapsDataReader"
+      },
+      "AzureRelayListener": {
+        "guid": "26e0b698-aa6d-4085-9386-aadae190014d",
+        "key": "AzureRelayListener"
+      },
+      "AzureRelayOwner": {
+        "guid": "2787bf04-f1f5-4bfe-8383-c8a24483ee38",
+        "key": "AzureRelayOwner"
+      },
+      "AzureRelaySender": {
+        "guid": "26baccc8-eea7-41f1-98f4-1762cc7f685d",
+        "key": "AzureRelaySender"
+      },
+      "AzureServiceBusDataOwner": {
+        "guid": "090c5cfd-751d-490a-894a-3ce6f1109419",
+        "key": "AzureServiceBusDataOwner"
+      },
+      "AzureServiceBusDataReceiver": {
+        "guid": "4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0",
+        "key": "AzureServiceBusDataReceiver"
+      },
+      "AzureServiceBusDataSender": {
+        "guid": "69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+        "key": "AzureServiceBusDataSender"
+      },
+      "AzureSpringCloudConfigServerContributor": {
+        "guid": "a06f5c24-21a7-4e1a-aa2b-f19eb6684f5b",
+        "key": "AzureSpringCloudConfigServerContributor"
+      },
+      "AzureSpringCloudConfigServerReader": {
+        "guid": "d04c6db6-4947-4782-9e91-30a88feb7be7",
+        "key": "AzureSpringCloudConfigServerReader"
+      },
+      "AzureSpringCloudDataReader": {
+        "guid": "b5537268-8956-4941-a8f0-646150406f0c",
+        "key": "AzureSpringCloudDataReader"
+      },
+      "AzureSpringCloudServiceRegistryContributor": {
+        "guid": "f5880b48-c26d-48be-b172-7927bfa1c8f1",
+        "key": "AzureSpringCloudServiceRegistryContributor"
+      },
+      "AzureSpringCloudServiceRegistryReader": {
+        "guid": "cff1b556-2399-4e7e-856d-a8f754be7b65",
+        "key": "AzureSpringCloudServiceRegistryReader"
+      },
+      "AzureStackRegistrationOwner": {
+        "guid": "6f12a6df-dd06-4f3e-bcb1-ce8be600526a",
+        "key": "AzureStackRegistrationOwner"
+      },
+      "BackupContributor": {
+        "guid": "5e467623-bb1f-42f4-a55d-6e525e11384b",
+        "key": "BackupContributor"
+      },
+      "BackupOperator": {
+        "guid": "00c29273-979b-4161-815c-10b084fb9324",
+        "key": "BackupOperator"
+      },
+      "BackupReader": {
+        "guid": "a795c7a0-d4a2-40c1-ae25-d81f01202912",
+        "key": "BackupReader"
+      },
+      "BillingReader": {
+        "guid": "fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64",
+        "key": "BillingReader"
+      },
+      "BizTalkContributor": {
+        "guid": "5e3c6656-6cfa-4708-81fe-0de47ac73342",
+        "key": "BizTalkContributor"
+      },
+      "BlueprintContributor": {
+        "guid": "41077137-e803-4205-871c-5a86e6a753b4",
+        "key": "BlueprintContributor"
+      },
+      "BlueprintOperator": {
+        "guid": "437d2ced-4a38-4302-8479-ed2bcb43d090",
+        "key": "BlueprintOperator"
+      },
+      "CarbonOptimizationReader": {
+        "guid": "fa0d39e6-28e5-40cf-8521-1eb320653a4c",
+        "key": "CarbonOptimizationReader"
+      },
+      "CdnEndpointContributor": {
+        "guid": "426e0c7f-0c7e-4658-b36f-ff54d6c29b45",
+        "key": "CdnEndpointContributor"
+      },
+      "CdnEndpointReader": {
+        "guid": "871e35f6-b5c1-49cc-a043-bde969a0f2cd",
+        "key": "CdnEndpointReader"
+      },
+      "CdnProfileContributor": {
+        "guid": "ec156ff8-a8d1-4d15-830c-5b80698ca432",
+        "key": "CdnProfileContributor"
+      },
+      "CdnProfileReader": {
+        "guid": "8f96442b-4075-438f-813d-ad51ab4019af",
+        "key": "CdnProfileReader"
+      },
+      "ClassicNetworkContributor": {
+        "guid": "b34d265f-36f7-4a0d-a4d4-e158ca92e90f",
+        "key": "ClassicNetworkContributor"
+      },
+      "ClassicStorageAccountContributor": {
+        "guid": "86e8f5dc-a6e9-4c67-9d15-de283e8eac25",
+        "key": "ClassicStorageAccountContributor"
+      },
+      "ClassicStorageAccountKeyOperatorServiceRole": {
+        "guid": "985d6b00-f706-48f5-a6fe-d0ca12fb668d",
+        "key": "ClassicStorageAccountKeyOperatorServiceRole"
+      },
+      "ClassicVirtualMachineContributor": {
+        "guid": "d73bb868-a0df-4d4d-bd69-98a00b01fccb",
+        "key": "ClassicVirtualMachineContributor"
+      },
+      "CognitiveServicesContributor": {
+        "guid": "25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+        "key": "CognitiveServicesContributor"
+      },
+      "CognitiveServicesCustomVisionContributor": {
+        "guid": "c1ff6cc2-c111-46fe-8896-e0ef812ad9f3",
+        "key": "CognitiveServicesCustomVisionContributor"
+      },
+      "CognitiveServicesCustomVisionDeployment": {
+        "guid": "5c4089e1-6d96-4d2f-b296-c1bc7137275f",
+        "key": "CognitiveServicesCustomVisionDeployment"
+      },
+      "CognitiveServicesCustomVisionLabeler": {
+        "guid": "88424f51-ebe7-446f-bc41-7fa16989e96c",
+        "key": "CognitiveServicesCustomVisionLabeler"
+      },
+      "CognitiveServicesCustomVisionReader": {
+        "guid": "93586559-c37d-4a6b-ba08-b9f0940c2d73",
+        "key": "CognitiveServicesCustomVisionReader"
+      },
+      "CognitiveServicesCustomVisionTrainer": {
+        "guid": "0a5ae4ab-0d65-4eeb-be61-29fc9b54394b",
+        "key": "CognitiveServicesCustomVisionTrainer"
+      },
+      "CognitiveServicesDataReader": {
+        "guid": "b59867f0-fa02-499b-be73-45a86b5b3e1c",
+        "key": "CognitiveServicesDataReader"
+      },
+      "CognitiveServicesFaceRecognizer": {
+        "guid": "9894cab4-e18a-44aa-828b-cb588cd6f2d7",
+        "key": "CognitiveServicesFaceRecognizer"
+      },
+      "CognitiveServicesMetricsAdvisorAdministrator": {
+        "guid": "cb43c632-a144-4ec5-977c-e80c4affc34a",
+        "key": "CognitiveServicesMetricsAdvisorAdministrator"
+      },
+      "CognitiveServicesOpenAIContributor": {
+        "guid": "a001fd3d-188f-4b5d-821b-7da978bf7442",
+        "key": "CognitiveServicesOpenAIContributor"
+      },
+      "CognitiveServicesOpenAIUser": {
+        "guid": "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
+        "key": "CognitiveServicesOpenAIUser"
+      },
+      "CognitiveServicesQnAMakerEditor": {
+        "guid": "f4cc2bf9-21be-47a1-bdf1-5c5804381025",
+        "key": "CognitiveServicesQnAMakerEditor"
+      },
+      "CognitiveServicesQnAMakerReader": {
+        "guid": "466ccd10-b268-4a11-b098-b4849f024126",
+        "key": "CognitiveServicesQnAMakerReader"
+      },
+      "CognitiveServicesUsagesReader": {
+        "guid": "bba48692-92b0-4667-a9ad-c31c7b334ac2",
+        "key": "CognitiveServicesUsagesReader"
+      },
+      "CognitiveServicesUser": {
+        "guid": "a97b65f3-24c7-4388-baec-2e87135dc908",
+        "key": "CognitiveServicesUser"
+      },
+      "ContainerAppReader": {
+        "guid": "ad2dd5fb-cd4b-4fd4-a9b6-4fed3630980b",
+        "key": "ContainerAppReader"
+      },
+      "ContainerAppsConnectedEnvironmentsContributor": {
+        "guid": "6f4fe6fc-f04f-4d97-8528-8bc18c848dca",
+        "key": "ContainerAppsConnectedEnvironmentsContributor"
+      },
+      "ContainerAppsConnectedEnvironmentsReader": {
+        "guid": "d5adeb5b-107f-4aca-99ea-4e3f4fc008d5",
+        "key": "ContainerAppsConnectedEnvironmentsReader"
+      },
+      "ContainerAppsContributor": {
+        "guid": "358470bc-b998-42bd-ab17-a7e34c199c0f",
+        "key": "ContainerAppsContributor"
+      },
+      "ContainerAppsJobsContributor": {
+        "guid": "4e3d2b60-56ae-4dc6-a233-09c8e5a82e68",
+        "key": "ContainerAppsJobsContributor"
+      },
+      "ContainerAppsJobsOperator": {
+        "guid": "b9a307c4-5aa3-4b52-ba60-2b17c136cd7b",
+        "key": "ContainerAppsJobsOperator"
+      },
+      "ContainerAppsJobsReader": {
+        "guid": "edd66693-d32a-450b-997d-0158c03976b0",
+        "key": "ContainerAppsJobsReader"
+      },
+      "ContainerAppsManagedEnvironmentsContributor": {
+        "guid": "57cc5028-e6a7-4284-868d-0611c5923f8d",
+        "key": "ContainerAppsManagedEnvironmentsContributor"
+      },
+      "ContainerAppsManagedEnvironmentsReader": {
+        "guid": "1b32c00b-7eff-4c22-93e6-93d11d72d2d8",
+        "key": "ContainerAppsManagedEnvironmentsReader"
+      },
+      "ContainerAppsOperator": {
+        "guid": "f3bd1b5c-91fa-40e7-afe7-0c11d331232c",
+        "key": "ContainerAppsOperator"
+      },
+      "ContainerAppsSessionExecutor": {
+        "guid": "0fb8eba5-a2bb-4abe-b1c1-49dfad359bb0",
+        "key": "ContainerAppsSessionExecutor"
+      },
+      "ContainerAppsSessionPoolsContributor": {
+        "guid": "f7669afb-68b2-44b4-9c5f-6d2a47fddda0",
+        "key": "ContainerAppsSessionPoolsContributor"
+      },
+      "ContainerRegistryRepositoryWriter": {
+        "guid": "2a1e307c-b015-4ebd-883e-5b7698a07328",
+        "key": "ContainerRegistryRepositoryWriter"
+      },
+      "ContainerRegistryTasksContributor": {
+        "guid": "fb382eab-e894-4461-af04-94435c366c3f",
+        "key": "ContainerRegistryTasksContributor"
+      },
+      "ContainerRegistryContributorDataAccessConfigurationAdministrator": {
+        "guid": "3bc748fc-213d-45c1-8d91-9da5725539b9",
+        "key": "ContainerRegistryContributorDataAccessConfigurationAdministrator"
+      },
+      "Contributor": {
+        "guid": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+        "key": "Contributor"
+      },
+      "CosmosBackupOperator": {
+        "guid": "db7b14f2-5adf-42da-9f96-f2ee17bab5cb",
+        "key": "CosmosBackupOperator"
+      },
+      "CosmosDBAccountReaderRole": {
+        "guid": "fbdf93bf-df7d-467e-a4d2-9458aa1360c8",
+        "key": "CosmosDBAccountReaderRole"
+      },
+      "CosmosDBBuiltInDataContributor": {
+        "guid": "00000000-0000-0000-0000-000000000002",
+        "key": "CosmosDBBuiltInDataContributor"
+      },
+      "CosmosDBBuiltInDataReader": {
+        "guid": "00000000-0000-0000-0000-000000000001",
+        "key": "CosmosDBBuiltInDataReader"
+      },
+      "CosmosDBOperator": {
+        "guid": "230815da-be43-4aae-9cb4-875f7bd000aa",
+        "key": "CosmosDBOperator"
+      },
+      "CosmosRestoreOperator": {
+        "guid": "5432c526-bc82-444a-b7ba-57c5b0b5b34f",
+        "key": "CosmosRestoreOperator"
+      },
+      "CostManagementContributor": {
+        "guid": "434105ed-43f6-45c7-a02f-909b2ba83430",
+        "key": "CostManagementContributor"
+      },
+      "CostManagementReader": {
+        "guid": "72fafb9e-0641-4937-9268-a91bfd8191a3",
+        "key": "CostManagementReader"
+      },
+      "DataBoxContributor": {
+        "guid": "add466c9-e687-43fc-8d98-dfcf8d720be5",
+        "key": "DataBoxContributor"
+      },
+      "DataBoxReader": {
+        "guid": "028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027",
+        "key": "DataBoxReader"
+      },
+      "DataFactoryContributor": {
+        "guid": "673868aa-7521-48a0-acc6-0f60742d39f5",
+        "key": "DataFactoryContributor"
+      },
+      "DataLakeAnalyticsDeveloper": {
+        "guid": "47b7735b-770e-4598-a7da-8b91488b4c88",
+        "key": "DataLakeAnalyticsDeveloper"
+      },
+      "DataOperatorForManagedDisks": {
+        "guid": "959f8984-c045-4866-89c7-12bf9737be2e",
+        "key": "DataOperatorForManagedDisks"
+      },
+      "DataPurger": {
+        "guid": "150f5e0c-0603-4f03-8c7f-cf70034c4e90",
+        "key": "DataPurger"
+      },
+      "DefenderForStorageDataScanner": {
+        "guid": "1e7ca9b1-60d1-4db8-a914-f2ca1ff27c40",
+        "key": "DefenderForStorageDataScanner"
+      },
+      "DesktopVirtualizationApplicationGroupContributor": {
+        "guid": "86240b0e-9422-4c43-887b-b61143f32ba8",
+        "key": "DesktopVirtualizationApplicationGroupContributor"
+      },
+      "DesktopVirtualizationApplicationGroupReader": {
+        "guid": "aebf23d0-b568-4e86-b8f9-fe83a2c6ab55",
+        "key": "DesktopVirtualizationApplicationGroupReader"
+      },
+      "DesktopVirtualizationContributor": {
+        "guid": "082f0a83-3be5-4ba1-904c-961cca79b387",
+        "key": "DesktopVirtualizationContributor"
+      },
+      "DesktopVirtualizationHostPoolContributor": {
+        "guid": "e307426c-f9b6-4e81-87de-d99efb3c32bc",
+        "key": "DesktopVirtualizationHostPoolContributor"
+      },
+      "DesktopVirtualizationHostPoolReader": {
+        "guid": "ceadfde2-b300-400a-ab7b-6143895aa822",
+        "key": "DesktopVirtualizationHostPoolReader"
+      },
+      "DesktopVirtualizationReader": {
+        "guid": "49a72310-ab8d-41df-bbb0-79b649203868",
+        "key": "DesktopVirtualizationReader"
+      },
+      "DesktopVirtualizationSessionHostOperator": {
+        "guid": "2ad6aaab-ead9-4eaa-8ac5-da422f562408",
+        "key": "DesktopVirtualizationSessionHostOperator"
+      },
+      "DesktopVirtualizationUser": {
+        "guid": "1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63",
+        "key": "DesktopVirtualizationUser"
+      },
+      "DesktopVirtualizationUserSessionOperator": {
+        "guid": "ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6",
+        "key": "DesktopVirtualizationUserSessionOperator"
+      },
+      "DesktopVirtualizationWorkspaceContributor": {
+        "guid": "21efdde3-836f-432b-bf3d-3e8e734d4b2b",
+        "key": "DesktopVirtualizationWorkspaceContributor"
+      },
+      "DesktopVirtualizationWorkspaceReader": {
+        "guid": "0fa44ee9-7a7d-466b-9bb2-2bf446b1204d",
+        "key": "DesktopVirtualizationWorkspaceReader"
+      },
+      "DevTestLabsUser": {
+        "guid": "76283e04-6283-4c54-8f91-bcf1374a3c64",
+        "key": "DevTestLabsUser"
+      },
+      "DeviceUpdateAdministrator": {
+        "guid": "02ca0879-e8e4-47a5-a61e-5c618b76e64a",
+        "key": "DeviceUpdateAdministrator"
+      },
+      "DeviceUpdateContentAdministrator": {
+        "guid": "0378884a-3af5-44ab-8323-f5b22f9f3c98",
+        "key": "DeviceUpdateContentAdministrator"
+      },
+      "DeviceUpdateContentReader": {
+        "guid": "d1ee9a80-8b14-47f0-bdc2-f4a351625a7b",
+        "key": "DeviceUpdateContentReader"
+      },
+      "DeviceUpdateDeploymentsAdministrator": {
+        "guid": "e4237640-0e3d-4a46-8fda-70bc94856432",
+        "key": "DeviceUpdateDeploymentsAdministrator"
+      },
+      "DeviceUpdateDeploymentsReader": {
+        "guid": "49e2f5d2-7741-4835-8efa-19e1fe35e47f",
+        "key": "DeviceUpdateDeploymentsReader"
+      },
+      "DeviceUpdateReader": {
+        "guid": "e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f",
+        "key": "DeviceUpdateReader"
+      },
+      "DiskBackupReader": {
+        "guid": "3e5e47e6-65f7-47ef-90b5-e5dd4d455f24",
+        "key": "DiskBackupReader"
+      },
+      "DiskPoolOperator": {
+        "guid": "60fc6e62-5479-42d4-8bf4-67625fcc2840",
+        "key": "DiskPoolOperator"
+      },
+      "DiskRestoreOperator": {
+        "guid": "b50d9833-a0cb-478e-945f-707fcc997c13",
+        "key": "DiskRestoreOperator"
+      },
+      "DiskSnapshotContributor": {
+        "guid": "7efff54f-a5b4-42b5-a1c5-5411624893ce",
+        "key": "DiskSnapshotContributor"
+      },
+      "DnsZoneContributor": {
+        "guid": "befefa01-2a29-4197-83a8-272ff33ce314",
+        "key": "DnsZoneContributor"
+      },
+      "DocumentDBAccountContributor": {
+        "guid": "5bd9cd88-fe45-4216-938b-f97437e15450",
+        "key": "DocumentDBAccountContributor"
+      },
+      "DomainServicesContributor": {
+        "guid": "eeaeda52-9324-47f6-8069-5d5bade478b2",
+        "key": "DomainServicesContributor"
+      },
+      "DomainServicesReader": {
+        "guid": "361898ef-9ed1-48c2-849c-a832951106bb",
+        "key": "DomainServicesReader"
+      },
+      "ElasticSANOwner": {
+        "guid": "80dcbedb-47ef-405d-95bd-188a1b4ac406",
+        "key": "ElasticSANOwner"
+      },
+      "ElasticSANReader": {
+        "guid": "af6a70f8-3c9f-4105-acf1-d719e9fca4ca",
+        "key": "ElasticSANReader"
+      },
+      "ElasticSANVolumeGroupOwner": {
+        "guid": "a8281131-f312-4f34-8d98-ae12be9f0d23",
+        "key": "ElasticSANVolumeGroupOwner"
+      },
+      "EventGridContributor": {
+        "guid": "1e241071-0855-49ea-94dc-649edcd759de",
+        "key": "EventGridContributor"
+      },
+      "EventGridDataSender": {
+        "guid": "d5a91429-5739-47e2-a06b-3470a27159e7",
+        "key": "EventGridDataSender"
+      },
+      "EventGridEventSubscriptionContributor": {
+        "guid": "428e0ff0-5e57-4d9c-a221-2c70d0e0a443",
+        "key": "EventGridEventSubscriptionContributor"
+      },
+      "EventGridEventSubscriptionReader": {
+        "guid": "2414bbcf-6497-4faf-8c65-045460748405",
+        "key": "EventGridEventSubscriptionReader"
+      },
+      "FhirDataContributor": {
+        "guid": "5a1fc7df-4bf1-4951-a576-89034ee01acd",
+        "key": "FhirDataContributor"
+      },
+      "FhirDataExporter": {
+        "guid": "3db33094-8700-4567-8da5-1501d4e7e843",
+        "key": "FhirDataExporter"
+      },
+      "FhirDataImporter": {
+        "guid": "4465e953-8ced-4406-a58e-0f6e3f3b530b",
+        "key": "FhirDataImporter"
+      },
+      "FhirDataReader": {
+        "guid": "4c8d0bbc-75d3-4935-991f-5f3c56d81508",
+        "key": "FhirDataReader"
+      },
+      "FhirDataWriter": {
+        "guid": "3f88fce4-5892-4214-ae73-ba5294559913",
+        "key": "FhirDataWriter"
+      },
+      "GrafanaAdmin": {
+        "guid": "22926164-76b3-42b3-bc55-97df8dab3e41",
+        "key": "GrafanaAdmin"
+      },
+      "GrafanaEditor": {
+        "guid": "a79a5197-3a5c-4973-a920-486035ffd60f",
+        "key": "GrafanaEditor"
+      },
+      "GrafanaViewer": {
+        "guid": "60921a7e-fef1-4a43-9b16-a26c52ad4769",
+        "key": "GrafanaViewer"
+      },
+      "HdInsightClusterOperator": {
+        "guid": "61ed4efc-fab3-44fd-b111-e24485cc132a",
+        "key": "HdInsightClusterOperator"
+      },
+      "HdInsightDomainServicesContributor": {
+        "guid": "8d8d5a11-05d3-4bda-a417-a08778121c7c",
+        "key": "HdInsightDomainServicesContributor"
+      },
+      "HierarchySettingsAdministrator": {
+        "guid": "350f8d15-c687-4448-8ae1-157740a3936d",
+        "key": "HierarchySettingsAdministrator"
+      },
+      "IntegrationServiceEnvironmentContributor": {
+        "guid": "a41e2c5b-bd99-4a07-88f4-9bf657a760b8",
+        "key": "IntegrationServiceEnvironmentContributor"
+      },
+      "IntegrationServiceEnvironmentDeveloper": {
+        "guid": "c7aa55d3-1abb-444a-a5ca-5e51e485d6ec",
+        "key": "IntegrationServiceEnvironmentDeveloper"
+      },
+      "IntelligentSystemsAccountContributor": {
+        "guid": "03a6d094-3444-4b3d-88af-7477090a9e5e",
+        "key": "IntelligentSystemsAccountContributor"
+      },
+      "IotHubDataContributor": {
+        "guid": "4fc6c259-987e-4a07-842e-c321cc9d413f",
+        "key": "IotHubDataContributor"
+      },
+      "IotHubDataReader": {
+        "guid": "b447c946-2db7-41ec-983d-d8bf3b1c77e3",
+        "key": "IotHubDataReader"
+      },
+      "IotHubRegistryContributor": {
+        "guid": "4ea46cd5-c1b2-4a8e-910b-273211f9ce47",
+        "key": "IotHubRegistryContributor"
+      },
+      "IotHubTwinContributor": {
+        "guid": "494bdba2-168f-4f31-a0a1-191d2f7c028c",
+        "key": "IotHubTwinContributor"
+      },
+      "KeyVaultAdministrator": {
+        "guid": "00482a5a-887f-4fb3-b363-3b7fe8e74483",
+        "key": "KeyVaultAdministrator"
+      },
+      "KeyVaultCertificateUser": {
+        "guid": "db79e9a7-68ee-4b58-9aeb-b90e7c24fcba",
+        "key": "KeyVaultCertificateUser"
+      },
+      "KeyVaultCertificatesOfficer": {
+        "guid": "a4417e6f-fecd-4de8-b567-7b0420556985",
+        "key": "KeyVaultCertificatesOfficer"
+      },
+      "KeyVaultContributor": {
+        "guid": "f25e0fa2-a7c8-4377-a976-54943a77a395",
+        "key": "KeyVaultContributor"
+      },
+      "KeyVaultCryptoOfficer": {
+        "guid": "14b46e9e-c2b7-41b4-b07b-48a6ebf60603",
+        "key": "KeyVaultCryptoOfficer"
+      },
+      "KeyVaultCryptoServiceEncryptionUser": {
+        "guid": "e147488a-f6f5-4113-8e2d-b22465e65bf6",
+        "key": "KeyVaultCryptoServiceEncryptionUser"
+      },
+      "KeyVaultCryptoServiceReleaseUser": {
+        "guid": "08bbd89e-9f13-488c-ac41-acfcb10c90ab",
+        "key": "KeyVaultCryptoServiceReleaseUser"
+      },
+      "KeyVaultCryptoUser": {
+        "guid": "12338af0-0e69-4776-bea7-57ae8d297424",
+        "key": "KeyVaultCryptoUser"
+      },
+      "KeyVaultDataAccessAdministrator": {
+        "guid": "8b54135c-b56d-4d72-a534-26097cfdc8d8",
+        "key": "KeyVaultDataAccessAdministrator"
+      },
+      "KeyVaultReader": {
+        "guid": "21090545-7ca7-4776-b22c-e363652d74d2",
+        "key": "KeyVaultReader"
+      },
+      "KeyVaultSecretsOfficer": {
+        "guid": "b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
+        "key": "KeyVaultSecretsOfficer"
+      },
+      "KeyVaultSecretsUser": {
+        "guid": "4633458b-17de-408a-b874-0445c86b69e6",
+        "key": "KeyVaultSecretsUser"
+      },
+      "KubernetesAgentlessOperator": {
+        "guid": "d5a2ae44-610b-4500-93be-660a0c5f5ca6",
+        "key": "KubernetesAgentlessOperator"
+      },
+      "KubernetesClusterAzureArcOnboarding": {
+        "guid": "34e09817-6cbe-4d01-b1a2-e0eac5743d41",
+        "key": "KubernetesClusterAzureArcOnboarding"
+      },
+      "KubernetesExtensionContributor": {
+        "guid": "85cb6faf-e071-4c9b-8136-154b5a04f717",
+        "key": "KubernetesExtensionContributor"
+      },
+      "LabAssistant": {
+        "guid": "ce40b423-cede-4313-a93f-9b28290b72e1",
+        "key": "LabAssistant"
+      },
+      "LabContributor": {
+        "guid": "5daaa2af-1fe8-407c-9122-bba179798270",
+        "key": "LabContributor"
+      },
+      "LabCreator": {
+        "guid": "b97fb8bc-a8b2-4522-a38b-dd33c7e65ead",
+        "key": "LabCreator"
+      },
+      "LabOperator": {
+        "guid": "a36e6959-b6be-4b12-8e9f-ef4b474d304d",
+        "key": "LabOperator"
+      },
+      "LabServicesContributor": {
+        "guid": "f69b8690-cc87-41d6-b77a-a4bc3c0a966f",
+        "key": "LabServicesContributor"
+      },
+      "LabServicesReader": {
+        "guid": "2a5c394f-5eb7-4d4f-9c8e-e8eae39faebc",
+        "key": "LabServicesReader"
+      },
+      "LoadTestContributor": {
+        "guid": "749a398d-560b-491b-bb21-08924219302e",
+        "key": "LoadTestContributor"
+      },
+      "LoadTestOwner": {
+        "guid": "45bb0b16-2f0c-4e78-afaa-a07599b003f6",
+        "key": "LoadTestOwner"
+      },
+      "LoadTestReader": {
+        "guid": "3ae3fb29-0000-4ccd-bf80-542e7b26e081",
+        "key": "LoadTestReader"
+      },
+      "LogAnalyticsContributor": {
+        "guid": "92aaf0da-9dab-42b6-94a3-d43ce8d16293",
+        "key": "LogAnalyticsContributor"
+      },
+      "LogAnalyticsReader": {
+        "guid": "73c42c96-874c-492b-b04d-ab87d138a893",
+        "key": "LogAnalyticsReader"
+      },
+      "LogicAppContributor": {
+        "guid": "87a39d53-fc1b-424a-814c-f7e04687dc9e",
+        "key": "LogicAppContributor"
+      },
+      "LogicAppOperator": {
+        "guid": "515c2055-d9d4-4321-b1b9-bd0c9a0f79fe",
+        "key": "LogicAppOperator"
+      },
+      "LogicAppsStandardContributor": {
+        "guid": "ad710c24-b039-4e85-a019-deb4a06e8570",
+        "key": "LogicAppsStandardContributor"
+      },
+      "LogicAppsStandardDeveloper": {
+        "guid": "523776ba-4eb2-4600-a3c8-f2dc93da4bdb",
+        "key": "LogicAppsStandardDeveloper"
+      },
+      "LogicAppsStandardOperator": {
+        "guid": "b70c96e9-66fe-4c09-b6e7-c98e69c98555",
+        "key": "LogicAppsStandardOperator"
+      },
+      "LogicAppsStandardReader": {
+        "guid": "4accf36b-2c05-432f-91c8-5c532dff4c73",
+        "key": "LogicAppsStandardReader"
+      },
+      "ManagedApplicationContributorRole": {
+        "guid": "641177b8-a67a-45b9-a033-47bc880bb21e",
+        "key": "ManagedApplicationContributorRole"
+      },
+      "ManagedApplicationOperatorRole": {
+        "guid": "c7393b34-138c-406f-901b-d8cf2b17e6ae",
+        "key": "ManagedApplicationOperatorRole"
+      },
+      "ManagedApplicationsReader": {
+        "guid": "b9331d33-8a36-4f8c-b097-4f54124fdb44",
+        "key": "ManagedApplicationsReader"
+      },
+      "ManagedHSMContributor": {
+        "guid": "18500a29-7fe2-46b2-a342-b16a415e101d",
+        "key": "ManagedHSMContributor"
+      },
+      "ManagedIdentityContributor": {
+        "guid": "e40ec5ca-96e0-45a2-b4ff-59039f2c2b59",
+        "key": "ManagedIdentityContributor"
+      },
+      "ManagedIdentityOperator": {
+        "guid": "f1a07417-d97a-45cb-824c-7a7467783830",
+        "key": "ManagedIdentityOperator"
+      },
+      "ManagedServicesRegistrationAssignmentDeleteRole": {
+        "guid": "91c1777a-f3dc-4fae-b103-61d183457e46",
+        "key": "ManagedServicesRegistrationAssignmentDeleteRole"
+      },
+      "ManagementGroupContributor": {
+        "guid": "5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c",
+        "key": "ManagementGroupContributor"
+      },
+      "ManagementGroupReader": {
+        "guid": "ac63b705-f282-497d-ac71-919bf39d939d",
+        "key": "ManagementGroupReader"
+      },
+      "MediaServicesAccountAdministrator": {
+        "guid": "054126f8-9a2b-4f1c-a9ad-eca461f08466",
+        "key": "MediaServicesAccountAdministrator"
+      },
+      "MediaServicesLiveEventsAdministrator": {
+        "guid": "532bc159-b25e-42c0-969e-a1d439f60d77",
+        "key": "MediaServicesLiveEventsAdministrator"
+      },
+      "MediaServicesMediaOperator": {
+        "guid": "e4395492-1534-4db2-bedf-88c14621589c",
+        "key": "MediaServicesMediaOperator"
+      },
+      "MediaServicesPolicyAdministrator": {
+        "guid": "c4bba371-dacd-4a26-b320-7250bca963ae",
+        "key": "MediaServicesPolicyAdministrator"
+      },
+      "MediaServicesStreamingEndpointsAdministrator": {
+        "guid": "99dba123-b5fe-44d5-874c-ced7199a5804",
+        "key": "MediaServicesStreamingEndpointsAdministrator"
+      },
+      "MicrosoftSentinelAutomationContributor": {
+        "guid": "f4c81013-99ee-4d62-a7ee-b3f1f648599a",
+        "key": "MicrosoftSentinelAutomationContributor"
+      },
+      "MicrosoftSentinelContributor": {
+        "guid": "ab8e14d6-4a74-4a29-9ba8-549422addade",
+        "key": "MicrosoftSentinelContributor"
+      },
+      "MicrosoftSentinelPlaybookOperator": {
+        "guid": "51d6186e-6489-4900-b93f-92e23144cca5",
+        "key": "MicrosoftSentinelPlaybookOperator"
+      },
+      "MicrosoftSentinelReader": {
+        "guid": "8d289c81-5878-46d4-8554-54e1e3d8b5cb",
+        "key": "MicrosoftSentinelReader"
+      },
+      "MicrosoftSentinelResponder": {
+        "guid": "3e150937-b8fe-4cfb-8069-0eaf05ecd056",
+        "key": "MicrosoftSentinelResponder"
+      },
+      "MonitoringContributor": {
+        "guid": "749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+        "key": "MonitoringContributor"
+      },
+      "MonitoringMetricsPublisher": {
+        "guid": "3913510d-42f4-4e42-8a64-420c390055eb",
+        "key": "MonitoringMetricsPublisher"
+      },
+      "MonitoringReader": {
+        "guid": "43d0d8ad-25c7-4714-9337-8ba259a9fe05",
+        "key": "MonitoringReader"
+      },
+      "NetworkContributor": {
+        "guid": "4d97b98b-1d4f-4787-a291-c67834d212e7",
+        "key": "NetworkContributor"
+      },
+      "NewRelicAPMAccountContributor": {
+        "guid": "5d28c62d-5b37-4476-8438-e587778df237",
+        "key": "NewRelicAPMAccountContributor"
+      },
+      "Owner": {
+        "guid": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+        "key": "Owner"
+      },
+      "PolicyInsightsDataWriter": {
+        "guid": "66bb4e9e-b016-4a94-8249-4c0511c2be84",
+        "key": "PolicyInsightsDataWriter"
+      },
+      "PrivateDNSZoneContributor": {
+        "guid": "b12aa53e-6015-4669-85d0-8515ebb3ae7f",
+        "key": "PrivateDNSZoneContributor"
+      },
+      "QuotaRequestOperator": {
+        "guid": "0e5f05e5-9ab9-446b-b98d-1e2157c94125",
+        "key": "QuotaRequestOperator"
+      },
+      "Reader": {
+        "guid": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
+        "key": "Reader"
+      },
+      "ReaderAndDataAccess": {
+        "guid": "c12c1c16-33a1-487b-954d-41c89c60f349",
+        "key": "ReaderAndDataAccess"
+      },
+      "RedisCacheContributor": {
+        "guid": "e0f68234-74aa-48ed-b826-c38b57376e17",
+        "key": "RedisCacheContributor"
+      },
+      "RemoteRenderingAdministrator": {
+        "guid": "3df8b902-2a6f-47c7-8cc5-360e9b272a7e",
+        "key": "RemoteRenderingAdministrator"
+      },
+      "RemoteRenderingClient": {
+        "guid": "d39065c4-c120-43c9-ab0a-63eed9795f0a",
+        "key": "RemoteRenderingClient"
+      },
+      "ReservationPurchaser": {
+        "guid": "f7b75c60-3036-4b75-91c3-6b41c27c1689",
+        "key": "ReservationPurchaser"
+      },
+      "ReservationsAdministrator": {
+        "guid": "a8889054-8d42-49c9-bc1c-52486c10e7cd",
+        "key": "ReservationsAdministrator"
+      },
+      "ReservationsReader": {
+        "guid": "582fc458-8989-419f-a480-75249bc5db7e",
+        "key": "ReservationsReader"
+      },
+      "ResourcePolicyContributor": {
+        "guid": "36243c78-bf99-498c-9df9-86d9f8d28608",
+        "key": "ResourcePolicyContributor"
+      },
+      "RoleBasedAccessControlAdministrator": {
+        "guid": "f58310d9-a9f6-439a-9e8d-f62e7b41a168",
+        "key": "RoleBasedAccessControlAdministrator"
+      },
+      "ScheduledPatchingContributor": {
+        "guid": "cd08ab90-6b14-449c-ad9a-8f8e549482c6",
+        "key": "ScheduledPatchingContributor"
+      },
+      "SchedulerJobCollectionsContributor": {
+        "guid": "188a0f2f-5c9e-469b-ae67-2aa5ce574b94",
+        "key": "SchedulerJobCollectionsContributor"
+      },
+      "SchemaRegistryContributor": {
+        "guid": "5dffeca3-4936-4216-b2bc-10343a5abb25",
+        "key": "SchemaRegistryContributor"
+      },
+      "SchemaRegistryReader": {
+        "guid": "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
+        "key": "SchemaRegistryReader"
+      },
+      "SearchIndexDataContributor": {
+        "guid": "8ebe5a00-799e-43f5-93ac-243d3dce84a7",
+        "key": "SearchIndexDataContributor"
+      },
+      "SearchIndexDataReader": {
+        "guid": "1407120a-92aa-4202-b7e9-c0e197c71c8f",
+        "key": "SearchIndexDataReader"
+      },
+      "SearchServiceContributor": {
+        "guid": "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
+        "key": "SearchServiceContributor"
+      },
+      "SecurityAdmin": {
+        "guid": "fb1c8493-542b-48eb-b624-b4c8fea62acd",
+        "key": "SecurityAdmin"
+      },
+      "SecurityAssessmentContributor": {
+        "guid": "612c2aa1-cb24-443b-ac28-3ab7272de6f5",
+        "key": "SecurityAssessmentContributor"
+      },
+      "SecurityReader": {
+        "guid": "39bc4728-0917-49c7-9d2c-d95423bc2eb4",
+        "key": "SecurityReader"
+      },
+      "ServicesHubOperator": {
+        "guid": "82200a5b-e217-47a5-b665-6d8765ee745b",
+        "key": "ServicesHubOperator"
+      },
+      "SignalRAccessKeyReader": {
+        "guid": "04165923-9d83-45d5-8227-78b77b0a687e",
+        "key": "SignalRAccessKeyReader"
+      },
+      "SignalRAppServer": {
+        "guid": "420fcaa2-552c-430f-98ca-3264be4806c7",
+        "key": "SignalRAppServer"
+      },
+      "SignalRRestAPIOwner": {
+        "guid": "fd53cd77-2268-407a-8f46-7e7863d0f521",
+        "key": "SignalRRestAPIOwner"
+      },
+      "SignalRRestAPIReader": {
+        "guid": "ddde6b66-c0df-4114-a159-3618637b3035",
+        "key": "SignalRRestAPIReader"
+      },
+      "SignalRServiceOwner": {
+        "guid": "7e4f1700-ea5a-4f59-8f37-079cfe29dce3",
+        "key": "SignalRServiceOwner"
+      },
+      "SignalRWebPubSubContributor": {
+        "guid": "8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761",
+        "key": "SignalRWebPubSubContributor"
+      },
+      "SiteRecoveryContributor": {
+        "guid": "6670b86e-a3f7-4917-ac9b-5d6ab1be4567",
+        "key": "SiteRecoveryContributor"
+      },
+      "SiteRecoveryOperator": {
+        "guid": "494ae006-db33-4328-bf46-533a6560a3ca",
+        "key": "SiteRecoveryOperator"
+      },
+      "SiteRecoveryReader": {
+        "guid": "dbaa88c4-0c30-4179-9fb3-46319faa6149",
+        "key": "SiteRecoveryReader"
+      },
+      "SpatialAnchorsAccountContributor": {
+        "guid": "8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827",
+        "key": "SpatialAnchorsAccountContributor"
+      },
+      "SpatialAnchorsAccountOwner": {
+        "guid": "70bbe301-9835-447d-afdd-19eb3167307c",
+        "key": "SpatialAnchorsAccountOwner"
+      },
+      "SpatialAnchorsAccountReader": {
+        "guid": "5d51204f-eb77-4b1c-b86a-2ec626c49413",
+        "key": "SpatialAnchorsAccountReader"
+      },
+      "SqlDBContributor": {
+        "guid": "9b7fa17d-e63e-47b0-bb0a-15c516ac86ec",
+        "key": "SqlDBContributor"
+      },
+      "SqlManagedInstanceContributor": {
+        "guid": "4939a1f6-9ae0-4e48-a1e0-f2cbe897382d",
+        "key": "SqlManagedInstanceContributor"
+      },
+      "SqlSecurityManager": {
+        "guid": "056cd41c-7e88-42e1-933e-88ba6a50c9c3",
+        "key": "SqlSecurityManager"
+      },
+      "SqlServerContributor": {
+        "guid": "6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437",
+        "key": "SqlServerContributor"
+      },
+      "StorageAccountBackupContributor": {
+        "guid": "e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1",
+        "key": "StorageAccountBackupContributor"
+      },
+      "StorageAccountContributor": {
+        "guid": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
+        "key": "StorageAccountContributor"
+      },
+      "StorageAccountKeyOperatorServiceRole": {
+        "guid": "81a9662b-bebf-436f-a333-f67b29880f12",
+        "key": "StorageAccountKeyOperatorServiceRole"
+      },
+      "StorageBlobDataContributor": {
+        "guid": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+        "key": "StorageBlobDataContributor"
+      },
+      "StorageBlobDataOwner": {
+        "guid": "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
+        "key": "StorageBlobDataOwner"
+      },
+      "StorageBlobDataReader": {
+        "guid": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+        "key": "StorageBlobDataReader"
+      },
+      "StorageBlobDelegator": {
+        "guid": "db58b8e5-c6ad-4a2a-8342-4190687cbf4a",
+        "key": "StorageBlobDelegator"
+      },
+      "StorageFileDataPrivilegedContributor": {
+        "guid": "69566ab7-960f-475b-8e7c-b3118f30c6bd",
+        "key": "StorageFileDataPrivilegedContributor"
+      },
+      "StorageFileDataPrivilegedReader": {
+        "guid": "b8eda974-7b85-4f76-af95-65846b26df6d",
+        "key": "StorageFileDataPrivilegedReader"
+      },
+      "StorageFileDataSMBShareContributor": {
+        "guid": "0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb",
+        "key": "StorageFileDataSMBShareContributor"
+      },
+      "StorageFileDataSMBShareElevatedContributor": {
+        "guid": "a7264617-510b-434b-a828-9731dc254ea7",
+        "key": "StorageFileDataSMBShareElevatedContributor"
+      },
+      "StorageFileDataSMBShareReader": {
+        "guid": "aba4ae5f-2193-4029-9191-0cb91df5e314",
+        "key": "StorageFileDataSMBShareReader"
+      },
+      "StorageQueueDataContributor": {
+        "guid": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
+        "key": "StorageQueueDataContributor"
+      },
+      "StorageQueueDataMessageProcessor": {
+        "guid": "8a0f0c08-91a1-4084-bc3d-661d67233fed",
+        "key": "StorageQueueDataMessageProcessor"
+      },
+      "StorageQueueDataMessageSender": {
+        "guid": "c6a89b2d-59bc-44d0-9896-0f6e12d7b80a",
+        "key": "StorageQueueDataMessageSender"
+      },
+      "StorageQueueDataReader": {
+        "guid": "19e7f393-937e-4f77-808e-94535e297925",
+        "key": "StorageQueueDataReader"
+      },
+      "StorageTableDataContributor": {
+        "guid": "0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3",
+        "key": "StorageTableDataContributor"
+      },
+      "StorageTableDataReader": {
+        "guid": "76199698-9eea-4c19-bc75-cec21354c6b6",
+        "key": "StorageTableDataReader"
+      },
+      "StreamAnalyticsQueryTester": {
+        "guid": "1ec5b3c1-b17e-4e25-8312-2acb3c3c5abf",
+        "key": "StreamAnalyticsQueryTester"
+      },
+      "SupportRequestContributor": {
+        "guid": "cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e",
+        "key": "SupportRequestContributor"
+      },
+      "TagContributor": {
+        "guid": "4a9ae827-6dc8-4573-8ac7-8239d42aa03f",
+        "key": "TagContributor"
+      },
+      "TemplateSpecContributor": {
+        "guid": "1c9b6475-caf0-4164-b5a1-2142a7116f4b",
+        "key": "TemplateSpecContributor"
+      },
+      "TemplateSpecReader": {
+        "guid": "392ae280-861d-42bd-9ea5-08ee6d83b80e",
+        "key": "TemplateSpecReader"
+      },
+      "TrafficManagerContributor": {
+        "guid": "a4b10055-b0c7-44c2-b00f-c7b5b3550cf7",
+        "key": "TrafficManagerContributor"
+      },
+      "UserAccessAdministrator": {
+        "guid": "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
+        "key": "UserAccessAdministrator"
+      },
+      "VirtualMachineAdministratorLogin": {
+        "guid": "1c0163c0-47e6-4577-8991-ea5c82e286e4",
+        "key": "VirtualMachineAdministratorLogin"
+      },
+      "VirtualMachineContributor": {
+        "guid": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
+        "key": "VirtualMachineContributor"
+      },
+      "VirtualMachineDataAccessAdministrator": {
+        "guid": "66f75aeb-eabe-4b70-9f1e-c350c4c9ad04",
+        "key": "VirtualMachineDataAccessAdministrator"
+      },
+      "VirtualMachineLocalUserLogin": {
+        "guid": "602da2ba-a5c2-41da-b01d-5360126ab525",
+        "key": "VirtualMachineLocalUserLogin"
+      },
+      "VirtualMachineUserLogin": {
+        "guid": "fb879df8-f326-4884-b1cf-06f3ad86be52",
+        "key": "VirtualMachineUserLogin"
+      },
+      "WebPlanContributor": {
+        "guid": "2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b",
+        "key": "WebPlanContributor"
+      },
+      "WebsiteContributor": {
+        "guid": "de139f84-1756-47ae-9be6-808fbbe84772",
+        "key": "WebsiteContributor"
+      },
+      "WindowsAdminCenterAdministratorLogin": {
+        "guid": "a6333a3e-0164-44c3-b281-7a577aff287f",
+        "key": "WindowsAdminCenterAdministratorLogin"
+      },
+      "WorkbookContributor": {
+        "guid": "e8ddcd69-c73f-4f9f-9844-4100522f16ad",
+        "key": "WorkbookContributor"
+      },
+      "WorkbookReader": {
+        "guid": "b279062a-9be3-42a0-92ae-8b3cf002ec4d",
+        "key": "WorkbookReader"
+      }
+    },
+    "_1.abbrs": "[variables('_1._2')]",
+    "_1.roles": "[variables('_1._3')]"
+  },
+  "resources": {
+    "resourceGroupTags": {
+      "type": "Microsoft.Resources/tags",
+      "apiVersion": "2025-04-01",
+      "name": "default",
+      "properties": {
+        "tags": "[union(parameters('deploymentTags'), createObject('TemplateName', 'Deploy Your AI Application in Prod', 'Type', if(parameters('networkIsolation'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name))]"
+      }
+    },
+    "keyVault": {
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2026-02-01",
+      "name": "[last(split(variables('effectiveKeyVaultResourceId'), '/'))]"
+    },
+    "postgreSqlPrivateDnsZone": {
+      "condition": "[and(parameters('deployPostgreSql'), parameters('postgreSqlNetworkIsolation'))]",
+      "type": "Microsoft.Network/privateDnsZones",
+      "apiVersion": "2024-06-01",
+      "name": "[variables('postgreSqlPrivateDnsZoneName')]",
+      "location": "global",
+      "tags": "[parameters('deploymentTags')]"
+    },
+    "postgreSqlPrivateDnsZoneVnetLink": {
+      "condition": "[and(and(parameters('deployPostgreSql'), parameters('postgreSqlNetworkIsolation')), parameters('deployPostgreSqlPrivateDnsLink'))]",
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+      "apiVersion": "2024-06-01",
+      "name": "[format('{0}/{1}', variables('postgreSqlPrivateDnsZoneName'), variables('effectivePostgreSqlPrivateDnsLinkName'))]",
+      "location": "global",
+      "properties": {
+        "virtualNetwork": {
+          "id": "[variables('effectiveVnetResourceId')]"
+        },
+        "registrationEnabled": false
+      },
+      "dependsOn": [
+        "postgreSqlPrivateDnsZone"
+      ]
+    },
+    "postgreSqlFlexibleServerResource": {
+      "condition": "[parameters('deployPostgreSql')]",
+      "existing": true,
+      "type": "Microsoft.DBforPostgreSQL/flexibleServers",
+      "apiVersion": "2025-08-01",
+      "name": "[parameters('postgreSqlServerName')]"
+    },
+    "postgreSqlAllowAzureServicesFirewallRule": {
+      "condition": "[and(and(parameters('deployPostgreSql'), not(parameters('postgreSqlNetworkIsolation'))), parameters('postgreSqlAllowAzureServices'))]",
+      "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
+      "apiVersion": "2025-08-01",
+      "name": "[format('{0}/{1}', parameters('postgreSqlServerName'), 'AllowAzureServices')]",
+      "properties": {
+        "startIpAddress": "0.0.0.0",
+        "endIpAddress": "0.0.0.0"
+      },
+      "dependsOn": [
+        "postgreSqlFlexibleServer"
+      ]
+    },
+    "postgreSqlAdminSecret": {
+      "condition": "[and(parameters('deployPostgreSql'), parameters('enablePostgreSqlKeyVaultSecret'))]",
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2026-02-01",
+      "name": "[format('{0}/{1}', last(split(variables('effectiveKeyVaultResourceId'), '/')), parameters('postgreSqlAdminSecretName'))]",
+      "properties": {
+        "value": "[variables('effectivePostgreSqlAdminPassword')]"
+      }
+    },
+    "postgreSqlFlexibleServer": {
+      "condition": "[parameters('deployPostgreSql')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "postgresql-flexible",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "availabilityZone": {
+            "value": "[parameters('postgreSqlAvailabilityZone')]"
+          },
+          "highAvailability": {
+            "value": "[parameters('postgreSqlHighAvailability')]"
+          },
+          "highAvailabilityZone": {
+            "value": "[parameters('postgreSqlHighAvailabilityZone')]"
+          },
+          "name": {
+            "value": "[parameters('postgreSqlServerName')]"
+          },
+          "skuName": {
+            "value": "[parameters('postgreSqlSkuName')]"
+          },
+          "tier": {
+            "value": "[parameters('postgreSqlTier')]"
+          },
+          "administratorLogin": {
+            "value": "[parameters('postgreSqlAdminLogin')]"
+          },
+          "administratorLoginPassword": {
+            "value": "[variables('effectivePostgreSqlAdminPassword')]"
+          },
+          "authConfig": {
+            "value": "[parameters('postgreSqlAuthConfig')]"
+          },
+          "managedIdentities": {
+            "value": {
+              "systemAssigned": true
+            }
+          },
+          "publicNetworkAccess": "[if(parameters('postgreSqlNetworkIsolation'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
+          "version": {
+            "value": "[parameters('postgreSqlVersion')]"
+          },
+          "storageSizeGB": {
+            "value": "[parameters('postgreSqlStorageSizeGB')]"
+          },
+          "privateEndpoints": {
+            "value": "[variables('postgreSqlPrivateEndpoints')]"
+          },
+          "tags": {
+            "value": "[parameters('deploymentTags')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.41.2.15936",
+              "templateHash": "8379823000734999523"
+            },
+            "name": "DBforPostgreSQL Flexible Servers",
+            "description": "This module deploys a DBforPostgreSQL Flexible Server."
+          },
+          "definitions": {
+            "privateEndpointOutputType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The name of the private endpoint."
+                  }
+                },
+                "resourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The resource ID of the private endpoint."
+                  }
+                },
+                "groupId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "The group Id for the private endpoint Group."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "fqdn": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "FQDN that resolves to private endpoint IP address."
+                        }
+                      },
+                      "ipAddresses": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "description": "A list of private IP addresses of the private endpoint."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "The custom DNS configurations of the private endpoint."
+                  }
+                },
+                "networkInterfaceResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "The IDs of the network interfaces associated with the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "replicaType": {
+              "type": "object",
+              "properties": {
+                "promoteMode": {
+                  "type": "string",
+                  "allowedValues": [
+                    "standalone",
+                    "switchover"
+                  ],
+                  "metadata": {
+                    "description": "Conditional. Sets the promote mode for a replica server. This is a write only property. Required if enabling replication."
+                  }
+                },
+                "promoteOption": {
+                  "type": "string",
+                  "allowedValues": [
+                    "forced",
+                    "planned"
+                  ],
+                  "metadata": {
+                    "description": "Conditional. Sets the promote options for a replica server. This is a write only property. Required if enabling replication."
+                  }
+                },
+                "role": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AsyncReplica",
+                    "GeoAsyncReplica",
+                    "None",
+                    "Primary"
+                  ],
+                  "metadata": {
+                    "description": "Conditional. Used to indicate role of the server in replication set. Required if enabling replication."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type of replication settings for the server. Can only be set on existing flexible servers."
+              }
+            },
+            "administratorType": {
+              "type": "object",
+              "properties": {
+                "objectId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The objectId of the Active Directory administrator."
+                  }
+                },
+                "principalName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Active Directory administrator principal name."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Group",
+                    "ServicePrincipal",
+                    "Unknown",
+                    "User"
+                  ],
+                  "metadata": {
+                    "description": "Required. The principal type used to represent the type of Active Directory Administrator."
+                  }
+                },
+                "tenantId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The tenantId of the Active Directory administrator."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type of an administrator."
+              }
+            },
+            "firewallRuleType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the PostgreSQL flexible server Firewall Rule."
+                  }
+                },
+                "startIpAddress": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' for all Azure-internal IP addresses."
+                  }
+                },
+                "endIpAddress": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The end IP address of the firewall rule. Must be IPv4 format. Must be greater than or equal to startIpAddress. Use value '0.0.0.0' for all Azure-internal IP addresses."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type of a firewall rule."
+              }
+            },
+            "_1.privateEndpointCustomDnsConfigType": {
+              "type": "object",
+              "properties": {
+                "fqdn": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. FQDN that resolves to private endpoint IP address."
+                  }
+                },
+                "ipAddresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. A list of private IP addresses of the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "_1.privateEndpointIpConfigurationType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the resource that is unique within a resource group."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "properties": {
+                    "groupId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "memberName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "privateIPAddress": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. Properties of private endpoint IP configurations."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "_1.privateEndpointPrivateDnsZoneGroupType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private DNS Zone Group."
+                  }
+                },
+                "privateDnsZoneGroupConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. The name of the private DNS Zone Group config."
+                        }
+                      },
+                      "privateDnsZoneResourceId": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. The resource id of the private DNS zone."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "customerManagedKeyWithAutoRotateType": {
+              "type": "object",
+              "properties": {
+                "keyVaultResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+                  }
+                },
+                "keyName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the customer managed key to use for encryption."
+                  }
+                },
+                "keyVersion": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+                  }
+                },
+                "autoRotationEnabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+                  }
+                },
+                "userAssignedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "diagnosticSettingFullType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the diagnostic setting."
+                  }
+                },
+                "logCategoriesAndGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                        }
+                      },
+                      "categoryGroup": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                  }
+                },
+                "metricCategories": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                  }
+                },
+                "logAnalyticsDestinationType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AzureDiagnostics",
+                    "Dedicated"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                  }
+                },
+                "workspaceResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "storageAccountResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "eventHubAuthorizationRuleResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                  }
+                },
+                "eventHubName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "marketplacePartnerResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "lockType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the name of lock."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "allowedValues": [
+                    "CanNotDelete",
+                    "None",
+                    "ReadOnly"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                },
+                "notes": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the notes of the lock."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "managedIdentityAllType": {
+              "type": "object",
+              "properties": {
+                "systemAssigned": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables system assigned managed identity on the resource."
+                  }
+                },
+                "userAssignedResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "privateEndpointSingleServiceType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private Endpoint."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The location to deploy the Private Endpoint to."
+                  }
+                },
+                "privateLinkServiceConnectionName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the private link connection to create."
+                  }
+                },
+                "service": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                  }
+                },
+                "subnetResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                  }
+                },
+                "resourceGroupResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                  }
+                },
+                "privateDnsZoneGroup": {
+                  "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                  }
+                },
+                "isManualConnection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. If Manual Private Link Connection is required."
+                  }
+                },
+                "manualConnectionRequestMessage": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 140,
+                  "metadata": {
+                    "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Custom DNS configurations."
+                  }
+                },
+                "ipConfigurations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                  }
+                },
+                "applicationSecurityGroupResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                  }
+                },
+                "customNetworkInterfaceName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                  }
+                },
+                "lock": {
+                  "$ref": "#/definitions/lockType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                },
+                "roleAssignments": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/roleAssignmentType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Array of role assignments to create."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.Network/privateEndpoints@2024-07-01#properties/tags"
+                    },
+                    "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                  }
+                },
+                "enableTelemetry": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable/Disable usage telemetry for module."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the PostgreSQL flexible server."
+              }
+            },
+            "administratorLogin": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The administrator login name of the server. Can only be specified when the PostgreSQL server is being created."
+              }
+            },
+            "administratorLoginPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The administrator login password."
+              }
+            },
+            "administrators": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/administratorType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The Azure AD administrators when AAD authentication enabled."
+              }
+            },
+            "authConfig": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.DBforPostgreSQL/flexibleServers@2025-06-01-preview#properties/properties/properties/authConfig"
+                },
+                "description": "Optional. The authentication configuration for the server."
+              },
+              "defaultValue": {
+                "activeDirectoryAuth": "Enabled",
+                "passwordAuth": "Disabled"
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "skuName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3."
+              }
+            },
+            "tier": {
+              "type": "string",
+              "allowedValues": [
+                "GeneralPurpose",
+                "Burstable",
+                "MemoryOptimized"
+              ],
+              "metadata": {
+                "description": "Required. The tier of the particular SKU. Tier must align with the 'skuName' property. Example, tier cannot be 'Burstable' if skuName is 'Standard_D4s_v3'."
+              }
+            },
+            "availabilityZone": {
+              "type": "int",
+              "allowedValues": [
+                -1,
+                1,
+                2,
+                3
+              ],
+              "metadata": {
+                "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones)."
+              }
+            },
+            "highAvailabilityZone": {
+              "type": "int",
+              "defaultValue": -1,
+              "allowedValues": [
+                -1,
+                1,
+                2,
+                3
+              ],
+              "metadata": {
+                "description": "Optional. Standby availability zone information of the server. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Default will have no preference set."
+              }
+            },
+            "highAvailability": {
+              "type": "string",
+              "defaultValue": "ZoneRedundant",
+              "allowedValues": [
+                "Disabled",
+                "SameZone",
+                "ZoneRedundant"
+              ],
+              "metadata": {
+                "description": "Optional. The mode for high availability."
+              }
+            },
+            "backupRetentionDays": {
+              "type": "int",
+              "defaultValue": 7,
+              "minValue": 7,
+              "maxValue": 35,
+              "metadata": {
+                "description": "Optional. Backup retention days for the server."
+              }
+            },
+            "geoRedundantBackup": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "description": "Optional. A value indicating whether Geo-Redundant backup is enabled on the server. Should be disabled if 'cMKKeyName' is not empty."
+              }
+            },
+            "storageSizeGB": {
+              "type": "int",
+              "defaultValue": 32,
+              "allowedValues": [
+                32,
+                64,
+                128,
+                256,
+                512,
+                1024,
+                2048,
+                4096,
+                8192,
+                16384
+              ],
+              "metadata": {
+                "description": "Optional. Max storage allowed for a server."
+              }
+            },
+            "autoGrow": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "description": "Optional. Flag to enable / disable Storage Auto grow for flexible server."
+              }
+            },
+            "version": {
+              "type": "string",
+              "defaultValue": "18",
+              "allowedValues": [
+                "11",
+                "12",
+                "13",
+                "14",
+                "15",
+                "16",
+                "17",
+                "18"
+              ],
+              "metadata": {
+                "description": "Optional. PostgreSQL Server version."
+              }
+            },
+            "createMode": {
+              "type": "string",
+              "defaultValue": "Default",
+              "allowedValues": [
+                "Create",
+                "Default",
+                "GeoRestore",
+                "PointInTimeRestore",
+                "Replica",
+                "Update"
+              ],
+              "metadata": {
+                "description": "Optional. The mode to create a new PostgreSQL server."
+              }
+            },
+            "managedIdentities": {
+              "$ref": "#/definitions/managedIdentityAllType",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The managed identity definition for this resource. Required if 'cMKKeyName' is not empty."
+              }
+            },
+            "serverThreatProtection": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "description": "Optional. Specifies the state of the Threat Protection, whether it is enabled or disabled or a state has not been applied yet on the specific server."
+              }
+            },
+            "customerManagedKey": {
+              "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The customer managed key definition."
+              }
+            },
+            "maintenanceWindow": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.DBforPostgreSQL/flexibleServers@2025-06-01-preview#properties/properties/properties/maintenanceWindow"
+                },
+                "description": "Optional. Properties for the maintenence window. If provided, 'customWindow' property must exist and set to 'Enabled'."
+              },
+              "defaultValue": {
+                "customWindow": "Enabled",
+                "dayOfWeek": 0,
+                "startHour": 1,
+                "startMinute": 0
+              }
+            },
+            "pointInTimeUTC": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Conditional. Required if 'createMode' is set to 'PointInTimeRestore'."
+              }
+            },
+            "sourceServerResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Conditional. Required if 'createMode' is set to 'PointInTimeRestore'."
+              }
+            },
+            "delegatedSubnetResourceId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Delegated subnet arm resource ID. Used when the desired connectivity mode is 'Private Access' - virtual network integration."
+              }
+            },
+            "privateDnsZoneArmResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Private dns zone arm resource ID. Used when the desired connectivity mode is 'Private Access' and required when 'delegatedSubnetResourceId' is used. The Private DNS Zone must be linked to the Virtual Network referenced in 'delegatedSubnetResourceId'."
+              }
+            },
+            "firewallRules": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/firewallRuleType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The firewall rules to create in the PostgreSQL flexible server."
+              }
+            },
+            "publicNetworkAccess": {
+              "type": "string",
+              "defaultValue": "Disabled",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "description": "Optional. Determines whether or not public network access is enabled or disabled."
+              }
+            },
+            "databases": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. The databases to create in the server."
+              }
+            },
+            "configurations": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. The configurations to create in the server."
+              }
+            },
+            "lock": {
+              "$ref": "#/definitions/lockType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The lock settings of the service."
+              }
+            },
+            "replica": {
+              "$ref": "#/definitions/replicaType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The replication settings for the server. Can only be set on existing flexible servers."
+              }
+            },
+            "replicationRole": {
+              "type": "string",
+              "defaultValue": "None",
+              "allowedValues": [
+                "Primary",
+                "AsyncReplica",
+                "GeoAsyncReplica",
+                "None"
+              ],
+              "metadata": {
+                "description": "Optional. The replication role for the server."
+              }
+            },
+            "enableAdvancedThreatProtection": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable advanced threat protection."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.DBforPostgreSQL/flexibleServers@2025-06-01-preview#properties/tags"
+                },
+                "description": "Optional. Tags of the resource."
+              },
+              "nullable": true
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "diagnosticSettings": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/diagnosticSettingFullType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The diagnostic settings of the service."
+              }
+            },
+            "privateEndpoints": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointSingleServiceType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Configuration details for private endpoints. Used when the desired connectivity mode is 'Public Access' and 'delegatedSubnetResourceId' is NOT used."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              }
+            ],
+            "enableReferencedModulesTelemetry": false,
+            "standByAvailabilityZone": "[tryGet(createObject('Disabled', -1, 'SameZone', parameters('availabilityZone'), 'ZoneRedundant', parameters('highAvailabilityZone')), parameters('highAvailability'))]",
+            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(variables('formattedUserAssignedIdentities'))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(variables('formattedUserAssignedIdentities'))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+            },
+            "isHSMManagedCMK": "[equals(tryGet(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), ''), '/'), 7), 'managedHSMs')]"
+          },
+          "resources": {
+            "cMKKeyVault::cMKKey": {
+              "condition": "[and(and(not(empty(parameters('customerManagedKey'))), not(variables('isHSMManagedCMK'))), and(not(empty(parameters('customerManagedKey'))), not(variables('isHSMManagedCMK'))))]",
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults/keys",
+              "apiVersion": "2024-11-01",
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+            },
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2024-03-01",
+              "name": "[format('46d3xbcp.res.dbforpostgresql-flexibleserver.{0}.{1}', replace('0.15.2', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "cMKKeyVault": {
+              "condition": "[and(not(empty(parameters('customerManagedKey'))), not(variables('isHSMManagedCMK')))]",
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2024-11-01",
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
+            },
+            "flexibleServer": {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers",
+              "apiVersion": "2025-06-01-preview",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "sku": {
+                "name": "[parameters('skuName')]",
+                "tier": "[parameters('tier')]"
+              },
+              "identity": "[variables('identity')]",
+              "properties": {
+                "administratorLogin": "[parameters('administratorLogin')]",
+                "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+                "authConfig": "[parameters('authConfig')]",
+                "availabilityZone": "[if(not(equals(parameters('availabilityZone'), -1)), string(parameters('availabilityZone')), null())]",
+                "highAvailability": {
+                  "mode": "[parameters('highAvailability')]",
+                  "standbyAvailabilityZone": "[if(not(equals(variables('standByAvailabilityZone'), -1)), string(variables('standByAvailabilityZone')), null())]"
+                },
+                "backup": {
+                  "backupRetentionDays": "[parameters('backupRetentionDays')]",
+                  "geoRedundantBackup": "[if(not(equals(parameters('createMode'), 'Replica')), parameters('geoRedundantBackup'), null())]"
+                },
+                "createMode": "[parameters('createMode')]",
+                "dataEncryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('primaryKeyURI', if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), if(not(variables('isHSMManagedCMK')), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, parameters('customerManagedKey').keyVersion), format('https://{0}.managedhsm.azure.net/keys/{1}/{2}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), parameters('customerManagedKey').keyName, parameters('customerManagedKey').keyVersion)), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), if(not(variables('isHSMManagedCMK')), reference('cMKKeyVault::cMKKey').keyUri, format('https://{0}.managedhsm.azure.net/keys/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), parameters('customerManagedKey').keyName)), if(not(variables('isHSMManagedCMK')), reference('cMKKeyVault::cMKKey').keyUriWithVersion, fail('Managed HSM CMK encryption requires either specifying the ''keyVersion'' or omitting the ''autoRotationEnabled'' property. Setting ''autoRotationEnabled'' to false without a ''keyVersion'' is not allowed.')))), 'primaryUserAssignedIdentityId', tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'type', 'AzureKeyVault'), null())]",
+                "maintenanceWindow": "[if(not(empty(parameters('maintenanceWindow'))), createObject('customWindow', parameters('maintenanceWindow').customWindow, 'dayOfWeek', if(equals(parameters('maintenanceWindow').customWindow, 'Enabled'), parameters('maintenanceWindow').dayOfWeek, 0), 'startHour', if(equals(parameters('maintenanceWindow').customWindow, 'Enabled'), parameters('maintenanceWindow').startHour, 0), 'startMinute', if(equals(parameters('maintenanceWindow').customWindow, 'Enabled'), parameters('maintenanceWindow').startMinute, 0)), null())]",
+                "network": "[if(and(not(empty(parameters('delegatedSubnetResourceId'))), empty(parameters('firewallRules'))), createObject('delegatedSubnetResourceId', parameters('delegatedSubnetResourceId'), 'privateDnsZoneArmResourceId', parameters('privateDnsZoneArmResourceId'), 'publicNetworkAccess', parameters('publicNetworkAccess')), createObject('publicNetworkAccess', parameters('publicNetworkAccess')))]",
+                "pointInTimeUTC": "[if(equals(parameters('createMode'), 'PointInTimeRestore'), parameters('pointInTimeUTC'), null())]",
+                "replica": "[if(not(empty(parameters('replica'))), parameters('replica'), null())]",
+                "replicationRole": "[parameters('replicationRole')]",
+                "sourceServerResourceId": "[if(or(equals(parameters('createMode'), 'PointInTimeRestore'), equals(parameters('createMode'), 'Replica')), parameters('sourceServerResourceId'), null())]",
+                "storage": {
+                  "storageSizeGB": "[parameters('storageSizeGB')]",
+                  "autoGrow": "[parameters('autoGrow')]"
+                },
+                "version": "[parameters('version')]"
+              },
+              "dependsOn": [
+                "cMKKeyVault::cMKKey"
+              ]
+            },
+            "flexibleServer_lock": {
+              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+              "type": "Microsoft.Authorization/locks",
+              "apiVersion": "2020-05-01",
+              "scope": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name'))]",
+              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+              "properties": {
+                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+              },
+              "dependsOn": [
+                "flexibleServer"
+              ]
+            },
+            "flexibleServer_roleAssignments": {
+              "copy": {
+                "name": "flexibleServer_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "flexibleServer"
+              ]
+            },
+            "flexibleServer_diagnosticSettings": {
+              "copy": {
+                "name": "flexibleServer_diagnosticSettings",
+                "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+              },
+              "type": "Microsoft.Insights/diagnosticSettings",
+              "apiVersion": "2021-05-01-preview",
+              "scope": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+              "properties": {
+                "copy": [
+                  {
+                    "name": "metrics",
+                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics'))))]",
+                    "input": {
+                      "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')].category]",
+                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')], 'enabled'), true())]",
+                      "timeGrain": null
+                    }
+                  },
+                  {
+                    "name": "logs",
+                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs'))))]",
+                    "input": {
+                      "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'categoryGroup')]",
+                      "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'category')]",
+                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'enabled'), true())]"
+                    }
+                  }
+                ],
+                "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+              },
+              "dependsOn": [
+                "flexibleServer"
+              ]
+            },
+            "flexibleServer_databases": {
+              "copy": {
+                "name": "flexibleServer_databases",
+                "count": "[length(parameters('databases'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-PostgreSQL-DB-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('databases')[copyIndex()].name]"
+                  },
+                  "flexibleServerName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "collation": {
+                    "value": "[tryGet(parameters('databases')[copyIndex()], 'collation')]"
+                  },
+                  "charset": {
+                    "value": "[tryGet(parameters('databases')[copyIndex()], 'charset')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "14389532095563872286"
+                    },
+                    "name": "DBforPostgreSQL Flexible Server Databases",
+                    "description": "This module deploys a DBforPostgreSQL Flexible Server Database."
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the database."
+                      }
+                    },
+                    "flexibleServerName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "collation": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The collation of the database."
+                      }
+                    },
+                    "charset": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The charset of the database."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "flexibleServer": {
+                      "existing": true,
+                      "type": "Microsoft.DBforPostgreSQL/flexibleServers",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[parameters('flexibleServerName')]"
+                    },
+                    "database": {
+                      "type": "Microsoft.DBforPostgreSQL/flexibleServers/databases",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('flexibleServerName'), parameters('name'))]",
+                      "properties": {
+                        "collation": "[parameters('collation')]",
+                        "charset": "[parameters('charset')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed database."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed database."
+                      },
+                      "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/databases', parameters('flexibleServerName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group name of the deployed database."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "flexibleServer",
+                "flexibleServer_roleAssignments"
+              ]
+            },
+            "flexibleServer_firewallRules": {
+              "copy": {
+                "name": "flexibleServer_firewallRules",
+                "count": "[length(coalesce(parameters('firewallRules'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-PostgreSQL-FirewallRules-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(parameters('firewallRules'), createArray())[copyIndex()].name]"
+                  },
+                  "flexibleServerName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "startIpAddress": {
+                    "value": "[coalesce(parameters('firewallRules'), createArray())[copyIndex()].startIpAddress]"
+                  },
+                  "endIpAddress": {
+                    "value": "[coalesce(parameters('firewallRules'), createArray())[copyIndex()].endIpAddress]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "3678239925427243942"
+                    },
+                    "name": "DBforPostgreSQL Flexible Server Firewall Rules",
+                    "description": "This module deploys a DBforPostgreSQL Flexible Server Firewall Rule."
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the PostgreSQL flexible server Firewall Rule."
+                      }
+                    },
+                    "startIpAddress": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' for all Azure-internal IP addresses."
+                      }
+                    },
+                    "endIpAddress": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The end IP address of the firewall rule. Must be IPv4 format. Must be greater than or equal to startIpAddress. Use value '0.0.0.0' for all Azure-internal IP addresses."
+                      }
+                    },
+                    "flexibleServerName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment."
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('flexibleServerName'), parameters('name'))]",
+                      "properties": {
+                        "endIpAddress": "[parameters('endIpAddress')]",
+                        "startIpAddress": "[parameters('startIpAddress')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed firewall rule."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed firewall rule."
+                      },
+                      "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/firewallRules', parameters('flexibleServerName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group of the deployed firewall rule."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "flexibleServer",
+                "flexibleServer_databases"
+              ]
+            },
+            "flexibleServer_configurations": {
+              "copy": {
+                "name": "flexibleServer_configurations",
+                "count": "[length(parameters('configurations'))]",
+                "mode": "serial",
+                "batchSize": 1
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-PostgreSQL-Configurations-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('configurations')[copyIndex()].name]"
+                  },
+                  "flexibleServerName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "source": {
+                    "value": "[tryGet(parameters('configurations')[copyIndex()], 'source')]"
+                  },
+                  "value": {
+                    "value": "[tryGet(parameters('configurations')[copyIndex()], 'value')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "12624936549152828907"
+                    },
+                    "name": "DBforPostgreSQL Flexible Server Configurations",
+                    "description": "This module deploys a DBforPostgreSQL Flexible Server Configuration."
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the configuration."
+                      }
+                    },
+                    "flexibleServerName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "source": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Source of the configuration."
+                      }
+                    },
+                    "value": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Value of the configuration."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "flexibleServer": {
+                      "existing": true,
+                      "type": "Microsoft.DBforPostgreSQL/flexibleServers",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[parameters('flexibleServerName')]"
+                    },
+                    "configuration": {
+                      "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('flexibleServerName'), parameters('name'))]",
+                      "properties": {
+                        "source": "[parameters('source')]",
+                        "value": "[parameters('value')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed configuration."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed configuration."
+                      },
+                      "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/configurations', parameters('flexibleServerName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group name of the deployed configuration."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "flexibleServer",
+                "flexibleServer_firewallRules"
+              ]
+            },
+            "flexibleServer_administrators": {
+              "copy": {
+                "name": "flexibleServer_administrators",
+                "count": "[length(coalesce(parameters('administrators'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-PostgreSQL-Administrators-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "flexibleServerName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "objectId": {
+                    "value": "[coalesce(parameters('administrators'), createArray())[copyIndex()].objectId]"
+                  },
+                  "principalName": {
+                    "value": "[coalesce(parameters('administrators'), createArray())[copyIndex()].principalName]"
+                  },
+                  "principalType": {
+                    "value": "[coalesce(parameters('administrators'), createArray())[copyIndex()].principalType]"
+                  },
+                  "tenantId": {
+                    "value": "[tryGet(coalesce(parameters('administrators'), createArray())[copyIndex()], 'tenantId')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "7486663780748986178"
+                    },
+                    "name": "DBforPostgreSQL Flexible Server Administrators",
+                    "description": "This module deploys a DBforPostgreSQL Flexible Server Administrator."
+                  },
+                  "parameters": {
+                    "flexibleServerName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "objectId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The objectId of the Active Directory administrator."
+                      }
+                    },
+                    "principalName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Active Directory administrator principal name."
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Group",
+                        "ServicePrincipal",
+                        "Unknown",
+                        "User"
+                      ],
+                      "metadata": {
+                        "description": "Required. The principal type used to represent the type of Active Directory Administrator."
+                      }
+                    },
+                    "tenantId": {
+                      "type": "string",
+                      "defaultValue": "[tenant().tenantId]",
+                      "metadata": {
+                        "description": "Optional. The tenantId of the Active Directory administrator."
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.DBforPostgreSQL/flexibleServers/administrators",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('flexibleServerName'), parameters('objectId'))]",
+                      "properties": {
+                        "principalName": "[parameters('principalName')]",
+                        "principalType": "[parameters('principalType')]",
+                        "tenantId": "[parameters('tenantId')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed administrator."
+                      },
+                      "value": "[parameters('objectId')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed administrator."
+                      },
+                      "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/administrators', parameters('flexibleServerName'), parameters('objectId'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group of the deployed administrator."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "flexibleServer",
+                "flexibleServer_configurations"
+              ]
+            },
+            "flexibleServer_advancedThreatProtection": {
+              "condition": "[parameters('enableAdvancedThreatProtection')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-PostgreSQL-Threat', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "serverThreatProtection": {
+                    "value": "[parameters('serverThreatProtection')]"
+                  },
+                  "flexibleServerName": {
+                    "value": "[parameters('name')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "3987804087046971868"
+                    },
+                    "name": "DBforPostgreSQL Flexible Server Advanced Threat Protection",
+                    "description": "This module deploys a DBforPostgreSQL Advanced Threat Protection."
+                  },
+                  "parameters": {
+                    "flexibleServerName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "serverThreatProtection": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Disabled",
+                        "Enabled"
+                      ],
+                      "metadata": {
+                        "description": "Required. Specifies the state of the Threat Protection, whether it is enabled or disabled or a state has not been applied yet on the specific server."
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[format('{0}/{1}', parameters('flexibleServerName'), 'PostgreSQL-advancedThreatProtection')]",
+                      "properties": {
+                        "state": "[parameters('serverThreatProtection')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource id of the advanced threat protection state for the flexible server."
+                      },
+                      "value": "PostgreSQL-advancedThreatProtection"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource id of the advanced threat protection state for the flexible server."
+                      },
+                      "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings', parameters('flexibleServerName'), 'PostgreSQL-advancedThreatProtection')]"
+                    },
+                    "advancedTreatProtectionState": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The advanced threat protection state for the flexible server."
+                      },
+                      "value": "[reference(resourceId('Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings', parameters('flexibleServerName'), 'PostgreSQL-advancedThreatProtection'), '2025-06-01-preview').state]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group of the deployed administrator."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "flexibleServer",
+                "flexibleServer_administrators"
+              ]
+            },
+            "server_privateEndpoints": {
+              "copy": {
+                "name": "server_privateEndpoints",
+                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
+              },
+              "condition": "[empty(parameters('delegatedSubnetResourceId'))]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-PostgreSQL-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
+              "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'name'), format('pep-{0}-{1}-{2}', last(split(resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'postgresqlServer'), copyIndex()))]"
+                  },
+                  "privateLinkServiceConnections": "[if(not(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true())), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'postgresqlServer'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'postgresqlServer')))))), createObject('value', null()))]",
+                  "manualPrivateLinkServiceConnections": "[if(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true()), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'postgresqlServer'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'postgresqlServer')), 'requestMessage', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'manualConnectionRequestMessage'), 'Manual approval required.'))))), createObject('value', null()))]",
+                  "subnetResourceId": {
+                    "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  },
+                  "location": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
+                  },
+                  "lock": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                  },
+                  "privateDnsZoneGroup": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateDnsZoneGroup')]"
+                  },
+                  "roleAssignments": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'roleAssignments')]"
+                  },
+                  "tags": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                  },
+                  "customDnsConfigs": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customDnsConfigs')]"
+                  },
+                  "ipConfigurations": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'ipConfigurations')]"
+                  },
+                  "applicationSecurityGroupResourceIds": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'applicationSecurityGroupResourceIds')]"
+                  },
+                  "customNetworkInterfaceName": {
+                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customNetworkInterfaceName')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.38.5.1644",
+                      "templateHash": "16604612898799598358"
+                    },
+                    "name": "Private Endpoints",
+                    "description": "This module deploys a Private Endpoint."
+                  },
+                  "definitions": {
+                    "privateDnsZoneGroupType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private DNS Zone Group."
+                          }
+                        },
+                        "privateDnsZoneGroupConfigs": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                          },
+                          "metadata": {
+                            "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type of a private dns zone group."
+                      }
+                    },
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        },
+                        "notes": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the notes of the lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                        }
+                      }
+                    },
+                    "privateDnsZoneGroupConfigType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the private DNS zone group config."
+                          }
+                        },
+                        "privateDnsZoneResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The resource id of the private DNS zone."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "The type of a private DNS zone group configuration.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "private-dns-zone-group/main.bicep"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the private endpoint resource to create."
+                      }
+                    },
+                    "subnetResourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                      }
+                    },
+                    "applicationSecurityGroupResourceIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
+                      }
+                    },
+                    "customNetworkInterfaceName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The custom name of the network interface attached to the private endpoint."
+                      }
+                    },
+                    "ipConfigurations": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/ipConfigurations"
+                        },
+                        "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+                      },
+                      "nullable": true
+                    },
+                    "privateDnsZoneGroup": {
+                      "$ref": "#/definitions/privateDnsZoneGroupType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The private DNS zone group to configure for the private endpoint."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all Resources."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/tags"
+                        },
+                        "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
+                      },
+                      "nullable": true
+                    },
+                    "customDnsConfigs": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/customDnsConfigs"
+                        },
+                        "description": "Optional. Custom DNS configurations."
+                      },
+                      "nullable": true
+                    },
+                    "manualPrivateLinkServiceConnections": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/manualPrivateLinkServiceConnections"
+                        },
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
+                      },
+                      "nullable": true
+                    },
+                    "privateLinkServiceConnections": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/privateLinkServiceConnections"
+                        },
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
+                      },
+                      "nullable": true
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                      "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                      "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                      "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                      "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.11.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "privateEndpoint": {
+                      "type": "Microsoft.Network/privateEndpoints",
+                      "apiVersion": "2024-10-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "copy": [
+                          {
+                            "name": "applicationSecurityGroups",
+                            "count": "[length(coalesce(parameters('applicationSecurityGroupResourceIds'), createArray()))]",
+                            "input": {
+                              "id": "[coalesce(parameters('applicationSecurityGroupResourceIds'), createArray())[copyIndex('applicationSecurityGroups')]]"
+                            }
+                          }
+                        ],
+                        "customDnsConfigs": "[coalesce(parameters('customDnsConfigs'), createArray())]",
+                        "customNetworkInterfaceName": "[coalesce(parameters('customNetworkInterfaceName'), '')]",
+                        "ipConfigurations": "[coalesce(parameters('ipConfigurations'), createArray())]",
+                        "manualPrivateLinkServiceConnections": "[coalesce(parameters('manualPrivateLinkServiceConnections'), createArray())]",
+                        "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
+                        "subnet": {
+                          "id": "[parameters('subnetResourceId')]"
+                        }
+                      }
+                    },
+                    "privateEndpoint_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+                      },
+                      "dependsOn": [
+                        "privateEndpoint"
+                      ]
+                    },
+                    "privateEndpoint_roleAssignments": {
+                      "copy": {
+                        "name": "privateEndpoint_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Network/privateEndpoints', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "privateEndpoint"
+                      ]
+                    },
+                    "privateEndpoint_privateDnsZoneGroup": {
+                      "condition": "[not(empty(parameters('privateDnsZoneGroup')))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-PrivateEndpoint-PrivateDnsZoneGroup', uniqueString(deployment().name))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[tryGet(parameters('privateDnsZoneGroup'), 'name')]"
+                          },
+                          "privateEndpointName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "privateDnsZoneConfigs": {
+                            "value": "[parameters('privateDnsZoneGroup').privateDnsZoneGroupConfigs]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.38.5.1644",
+                              "templateHash": "24141742673128945"
+                            },
+                            "name": "Private Endpoint Private DNS Zone Groups",
+                            "description": "This module deploys a Private Endpoint Private DNS Zone Group."
+                          },
+                          "definitions": {
+                            "privateDnsZoneGroupConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the private DNS zone group config."
+                                  }
+                                },
+                                "privateDnsZoneResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The resource id of the private DNS zone."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type of a private DNS zone group configuration."
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "privateEndpointName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent private endpoint. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "privateDnsZoneConfigs": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                              },
+                              "minLength": 1,
+                              "maxLength": 5,
+                              "metadata": {
+                                "description": "Required. Array of private DNS zone configurations of the private DNS zone group. A DNS zone group can support up to 5 DNS zones."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "default",
+                              "metadata": {
+                                "description": "Optional. The name of the private DNS zone group."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "privateEndpoint": {
+                              "existing": true,
+                              "type": "Microsoft.Network/privateEndpoints",
+                              "apiVersion": "2024-10-01",
+                              "name": "[parameters('privateEndpointName')]"
+                            },
+                            "privateDnsZoneGroup": {
+                              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                              "apiVersion": "2024-10-01",
+                              "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "privateDnsZoneConfigs",
+                                    "count": "[length(parameters('privateDnsZoneConfigs'))]",
+                                    "input": {
+                                      "name": "[coalesce(tryGet(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')], 'name'), last(split(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId, '/')))]",
+                                      "properties": {
+                                        "privateDnsZoneId": "[parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId]"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the private endpoint DNS zone group."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the private endpoint DNS zone group."
+                              },
+                              "value": "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', parameters('privateEndpointName'), parameters('name'))]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the private endpoint DNS zone group was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "privateEndpoint"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group the private endpoint was deployed into."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the private endpoint."
+                      },
+                      "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the private endpoint."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('privateEndpoint', '2024-10-01', 'full').location]"
+                    },
+                    "customDnsConfigs": {
+                      "type": "array",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/customDnsConfigs",
+                          "output": true
+                        },
+                        "description": "The custom DNS configurations of the private endpoint."
+                      },
+                      "value": "[reference('privateEndpoint').customDnsConfigs]"
+                    },
+                    "networkInterfaceResourceIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "description": "The resource IDs of the network interfaces associated with the private endpoint."
+                      },
+                      "value": "[map(reference('privateEndpoint').networkInterfaces, lambda('nic', lambdaVariables('nic').id))]"
+                    },
+                    "groupId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The group Id for the private endpoint Group."
+                      },
+                      "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'manualPrivateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0), tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'privateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0))]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "flexibleServer"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed PostgreSQL Flexible server."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed PostgreSQL Flexible server."
+              },
+              "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed PostgreSQL Flexible server."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location the resource was deployed into."
+              },
+              "value": "[reference('flexibleServer', '2025-06-01-preview', 'full').location]"
+            },
+            "fqdn": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "The FQDN of the PostgreSQL Flexible server."
+              },
+              "value": "[tryGet(reference('flexibleServer'), 'fullyQualifiedDomainName')]"
+            },
+            "privateEndpoints": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointOutputType"
+              },
+              "metadata": {
+                "description": "The private endpoints of the PostgreSQL Flexible server."
+              },
+              "copy": {
+                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]",
+                "input": {
+                  "name": "[reference(format('server_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
+                  "resourceId": "[reference(format('server_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
+                  "groupId": "[tryGet(tryGet(reference(format('server_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
+                  "customDnsConfigs": "[reference(format('server_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfigs.value]",
+                  "networkInterfaceResourceIds": "[reference(format('server_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
+                }
+              }
+            },
+            "systemAssignedMIPrincipalId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "The principal ID of the system assigned managed identity."
+              },
+              "value": "[tryGet(tryGet(reference('flexibleServer', '2025-06-01-preview', 'full'), 'identity'), 'principalId')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "postgreSqlPrivateDnsZone"
+      ]
+    },
+    "fabricCapacity": {
+      "condition": "[equals(variables('effectiveFabricCapacityMode'), 'create')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "fabric-capacity",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "capacityName": {
+            "value": "[variables('capacityName')]"
+          },
+          "location": {
+            "value": "[variables('effectiveLocation')]"
+          },
+          "sku": {
+            "value": "[parameters('fabricCapacitySku')]"
+          },
+          "adminMembers": {
+            "value": "[union(if(equals(tryGet(deployer(), 'userPrincipalName'), null()), createArray(deployer().objectId), createArray(deployer().userPrincipalName)), parameters('fabricCapacityAdmins'))]"
+          },
+          "tags": {
+            "value": "[parameters('deploymentTags')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.42.1.51946",
+              "templateHash": "12325469206187179338"
+            }
+          },
+          "parameters": {
+            "capacityName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Fabric capacity."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for the capacity."
+              }
+            },
+            "sku": {
+              "type": "string",
+              "defaultValue": "F8",
+              "allowedValues": [
+                "F2",
+                "F4",
+                "F8",
+                "F16",
+                "F32",
+                "F64",
+                "F128",
+                "F256",
+                "F512",
+                "F1024",
+                "F2048"
+              ],
+              "metadata": {
+                "description": "Fabric capacity SKU."
+              }
+            },
+            "adminMembers": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Array of admin email addresses or object IDs."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Tags to apply to the capacity."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Fabric/capacities",
+              "apiVersion": "2023-11-01",
+              "name": "[parameters('capacityName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "sku": {
+                "name": "[parameters('sku')]",
+                "tier": "Fabric"
+              },
+              "properties": {
+                "administration": {
+                  "members": "[parameters('adminMembers')]"
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Fabric capacity resource ID."
+              },
+              "value": "[resourceId('Microsoft.Fabric/capacities', parameters('capacityName'))]"
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Fabric capacity name."
+              },
+              "value": "[parameters('capacityName')]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Fabric capacity location."
+              },
+              "value": "[reference(resourceId('Microsoft.Fabric/capacities', parameters('capacityName')), '2023-11-01', 'full').location]"
+            },
+            "sku": {
+              "type": "string",
+              "metadata": {
+                "description": "Fabric capacity SKU."
+              },
+              "value": "[reference(resourceId('Microsoft.Fabric/capacities', parameters('capacityName')), '2023-11-01', 'full').sku.name]"
+            },
+            "capacityId": {
+              "type": "string",
+              "metadata": {
+                "description": "Fabric capacity Azure resource ID (for Azure API calls)."
+              },
+              "value": "[resourceId('Microsoft.Fabric/capacities', parameters('capacityName'))]"
+            }
+          }
+        }
+      }
+    }
+  },
+  "outputs": {
+    "virtualNetworkResourceId": {
+      "type": "string",
+      "value": "[variables('effectiveVnetResourceId')]"
+    },
+    "keyVaultResourceId": {
+      "type": "string",
+      "value": "[variables('effectiveKeyVaultResourceId')]"
+    },
+    "storageAccountResourceId": {
+      "type": "string",
+      "value": "[variables('effectiveStorageAccountResourceId')]"
+    },
+    "aiFoundryProjectName": {
+      "type": "string",
+      "value": "[parameters('aiFoundryProjectName')]"
+    },
+    "aiSearchResourceId": {
+      "type": "string",
+      "value": "[variables('effectiveAiSearchResourceId')]"
+    },
+    "aiSearchName": {
+      "type": "string",
+      "value": "[parameters('searchServiceName')]"
+    },
+    "aiSearchAdditionalAccessObjectIds": {
+      "type": "array",
+      "value": "[parameters('aiSearchAdditionalAccessObjectIds')]"
+    },
+    "peSubnetResourceId": {
+      "type": "string",
+      "value": "[format('{0}/subnets/{1}', variables('effectiveVnetResourceId'), parameters('peSubnetName'))]"
+    },
+    "jumpboxSubnetResourceId": {
+      "type": "string",
+      "value": "[format('{0}/subnets/{1}', variables('effectiveVnetResourceId'), parameters('jumpboxSubnetName'))]"
+    },
+    "agentSubnetResourceId": {
+      "type": "string",
+      "value": "[format('{0}/subnets/{1}', variables('effectiveVnetResourceId'), parameters('agentSubnetName'))]"
+    },
+    "fabricCapacityModeOut": {
+      "type": "string",
+      "value": "[variables('effectiveFabricCapacityMode')]"
+    },
+    "fabricWorkspaceModeOut": {
+      "type": "string",
+      "value": "[variables('effectiveFabricWorkspaceMode')]"
+    },
+    "fabricCapacityResourceIdOut": {
+      "type": "string",
+      "value": "[if(equals(variables('effectiveFabricCapacityMode'), 'create'), reference('fabricCapacity').outputs.resourceId.value, if(equals(variables('effectiveFabricCapacityMode'), 'byo'), parameters('fabricCapacityResourceId'), ''))]"
+    },
+    "fabricCapacityName": {
+      "type": "string",
+      "value": "[if(equals(variables('effectiveFabricCapacityMode'), 'create'), reference('fabricCapacity').outputs.name.value, if(not(empty(if(equals(variables('effectiveFabricCapacityMode'), 'create'), reference('fabricCapacity').outputs.resourceId.value, if(equals(variables('effectiveFabricCapacityMode'), 'byo'), parameters('fabricCapacityResourceId'), '')))), last(split(if(equals(variables('effectiveFabricCapacityMode'), 'create'), reference('fabricCapacity').outputs.resourceId.value, if(equals(variables('effectiveFabricCapacityMode'), 'byo'), parameters('fabricCapacityResourceId'), '')), '/')), ''))]"
+    },
+    "fabricCapacityId": {
+      "type": "string",
+      "value": "[if(equals(variables('effectiveFabricCapacityMode'), 'create'), reference('fabricCapacity').outputs.resourceId.value, if(equals(variables('effectiveFabricCapacityMode'), 'byo'), parameters('fabricCapacityResourceId'), ''))]"
+    },
+    "postgreSqlServerNameOut": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), reference('postgreSqlFlexibleServer').outputs.name.value, '')]"
+    },
+    "postgreSqlServerResourceId": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), reference('postgreSqlFlexibleServer').outputs.resourceId.value, '')]"
+    },
+    "postgreSqlServerFqdn": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), reference('postgreSqlFlexibleServer').outputs.fqdn.value, '')]"
+    },
+    "postgreSqlSystemAssignedPrincipalId": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), reference('postgreSqlFlexibleServer').outputs.systemAssignedMIPrincipalId.value, '')]"
+    },
+    "postgreSqlAdminSecretName": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSql'), parameters('enablePostgreSqlKeyVaultSecret')), parameters('postgreSqlAdminSecretName'), '')]"
+    },
+    "postgreSqlAdminLoginOut": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), parameters('postgreSqlAdminLogin'), '')]"
+    },
+    "postgreSqlFabricUserNameOut": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), parameters('postgreSqlFabricUserName'), '')]"
+    },
+    "postgreSqlFabricUserSecretNameOut": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSql'), parameters('enablePostgreSqlKeyVaultSecret')), parameters('postgreSqlFabricUserSecretName'), '')]"
+    },
+    "postgreSqlMirrorConnectionModeOut": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), parameters('postgreSqlMirrorConnectionMode'), '')]"
+    },
+    "postgreSqlMirrorConnectionUserNameOut": {
+      "type": "string",
+      "value": "[if(parameters('deployPostgreSql'), if(equals(parameters('postgreSqlMirrorConnectionMode'), 'admin'), parameters('postgreSqlAdminLogin'), parameters('postgreSqlFabricUserName')), '')]"
+    },
+    "postgreSqlMirrorConnectionSecretNameOut": {
+      "type": "string",
+      "value": "[if(and(parameters('deployPostgreSql'), parameters('enablePostgreSqlKeyVaultSecret')), if(equals(parameters('postgreSqlMirrorConnectionMode'), 'admin'), parameters('postgreSqlAdminSecretName'), parameters('postgreSqlFabricUserSecretName')), '')]"
+    },
+    "fabricWorkspaceNameOut": {
+      "type": "string",
+      "value": "[variables('effectiveFabricWorkspaceName')]"
+    },
+    "fabricWorkspaceIdOut": {
+      "type": "string",
+      "value": "[variables('effectiveFabricWorkspaceId')]"
+    },
+    "desiredFabricDomainName": {
+      "type": "string",
+      "value": "[if(not(empty(parameters('environmentName'))), format('domain-{0}', parameters('environmentName')), format('domain-{0}', parameters('baseName')))]"
+    },
+    "desiredFabricWorkspaceName": {
+      "type": "string",
+      "value": "[variables('effectiveFabricWorkspaceName')]"
+    },
+    "purviewAccountResourceId": {
+      "type": "string",
+      "value": "[parameters('purviewAccountResourceId')]"
+    },
+    "purviewCollectionName": {
+      "type": "string",
+      "value": "[if(not(empty(parameters('purviewCollectionName'))), parameters('purviewCollectionName'), if(not(empty(parameters('environmentName'))), format('collection-{0}', parameters('environmentName')), format('collection-{0}', parameters('baseName'))))]"
+    }
+  }
+}

--- a/infra/modules/fabricPrivateEndpoint.bicep
+++ b/infra/modules/fabricPrivateEndpoint.bicep
@@ -38,7 +38,7 @@ param privateDnsZoneIds array = []
 // PRIVATE ENDPOINT
 // ========================================
 
-resource fabricPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-09-01' = {
+resource fabricPrivateEndpoint 'Microsoft.Network/privateEndpoints@2025-07-01' = {
   name: privateEndpointName
   location: location
   tags: tags
@@ -65,7 +65,7 @@ resource fabricPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-09-01' =
 // PRIVATE DNS ZONE GROUPS
 // ========================================
 
-resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-09-01' = if (enablePrivateDnsIntegration && !empty(privateDnsZoneIds)) {
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-07-01' = if (enablePrivateDnsIntegration && !empty(privateDnsZoneIds)) {
   parent: fabricPrivateEndpoint
   name: 'default'
   properties: {


### PR DESCRIPTION
## Purpose
This pull request updates several Azure resource definitions in the Bicep infrastructure code to use newer API versions, ensuring compatibility with the latest Azure features and improvements. The changes primarily focus on PostgreSQL Flexible Server, Key Vault, Private DNS Zones, and Private Endpoints.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Golden Path Validation
- [X] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.

