### PR TITLE
fix: Remove hardcoded VM admin password and improve credential security

### DIFF
--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -209,15 +209,10 @@ For network-isolated deployments, set the VM credentials before running `azd up`
 
 ```powershell
 azd env set VM_ADMIN_USERNAME "youradminuser"
-azd env set VM_ADMIN_PASSWORD "Use-A-Strong-Password-Here!"
+azd env set VM_ADMIN_PASSWORD "<your-strong-password>"
 ```
 
-If you prefer source-controlled defaults, set them in [infra/main.bicepparam](../infra/main.bicepparam) instead:
-
-```bicep
-param vmUserName = 'youradminuser'
-param vmAdminPassword = 'Use-A-Strong-Password-Here!'
-```
+> ⚠️ **Security Warning:** Do **not** commit VM passwords to source control. Always use `azd env set`, a secrets manager, or pipeline secret variables for sensitive credentials. The `infra/main.bicepparam` file reads the password from the `VM_ADMIN_PASSWORD` environment variable at deployment time — no default is provided intentionally, so deployment will prompt or fail if the variable is unset.
 
 </details>
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -205,7 +205,7 @@ param containerAppsList = [
 ]
 
 param vmUserName = readEnvironmentVariable('VM_ADMIN_USERNAME', 'testvmuser')
-param vmAdminPassword = readEnvironmentVariable('VM_ADMIN_PASSWORD', 'JumpboxAdminP@ssw0rd1234!')
+param vmAdminPassword = readEnvironmentVariable('VM_ADMIN_PASSWORD', '')
 param vmSize = 'Standard_D2s_v4'
 
 // ========================================

--- a/scripts/quota_check.sh
+++ b/scripts/quota_check.sh
@@ -180,6 +180,7 @@ MODEL_COUNT=${#MODEL_NAMES[@]}
 
 # ---- Results tracking ----
 declare -A REGION_STATUS
+declare -A RESULTS
 VALID_REGIONS=()
 
 # ---- Main quota check loop ----
@@ -213,7 +214,7 @@ for REGION in "${REGIONS[@]}"; do
                 echo "      (Looked for: $primary_key${alt_key:+, $alt_key})"
             fi
             ALL_PASS=false
-            eval "RESULT_${safe_region}_${i}=N_A"
+            RESULTS["${safe_region}:${i}"]="N_A"
             continue
         fi
 
@@ -223,7 +224,7 @@ for REGION in "${REGIONS[@]}"; do
         LIMIT=${LIMIT%%.*}
         AVAILABLE=$((LIMIT - CURRENT))
 
-        eval "RESULT_${safe_region}_${i}=${AVAILABLE}_${LIMIT}"
+        RESULTS["${safe_region}:${i}"]="${AVAILABLE}_${LIMIT}"
 
         if [[ "$AVAILABLE" -lt "$mcap" ]]; then
             echo "   ❌ $display | Used: $CURRENT | Limit: $LIMIT | Available: $AVAILABLE | Need: $mcap"
@@ -291,7 +292,7 @@ for REGION in "${REGIONS[@]}"; do
 
     for ((i=0; i<MODEL_COUNT; i++)); do
         mcap="${MODEL_CAPS[$i]}"
-        eval "val=\${RESULT_${safe_region}_${i}:-N_A}"
+        val="${RESULTS["${safe_region}:${i}"]:-N_A}"
 
         if [[ "$val" == "N_A" ]]; then
             printf "%-30s" "⚠️  N/A"


### PR DESCRIPTION
## Purpose

This pull request improves security practices for handling VM admin passwords in deployment and refactors how quota check results are tracked in the `scripts/quota_check.sh` script. The most important changes are grouped below:

**Security and Deployment Documentation:**

* Updated `docs/deploymentguide.md` to emphasize that VM admin passwords should never be committed to source control. Guidance now recommends using environment variables or secret managers, and clarifies that `infra/main.bicepparam` intentionally provides no default password—deployment will prompt or fail if unset.
* Changed the default value for the `vmAdminPassword` parameter in `infra/main.bicepparam` to an empty string, removing the insecure default password.

**Quota Check Script Refactoring:**

* Replaced the use of dynamic variable names (with `eval`) for tracking quota check results with an associative array `RESULTS` for safer and clearer result storage in `scripts/quota_check.sh`. [[1]](diffhunk://#diff-37ad3a250267af41c1029370d27c2f3536994279686fda648f443a11dedcfbfeR183) [[2]](diffhunk://#diff-37ad3a250267af41c1029370d27c2f3536994279686fda648f443a11dedcfbfeL216-R217) [[3]](diffhunk://#diff-37ad3a250267af41c1029370d27c2f3536994279686fda648f443a11dedcfbfeL226-R227) [[4]](diffhunk://#diff-37ad3a250267af41c1029370d27c2f3536994279686fda648f443a11dedcfbfeL294-R295)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

