### PR TITLE
docs: Fix default value for fabricCapacityMode in documentation

### DIFF
--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -195,14 +195,14 @@ Edit `infra/main.bicepparam` or set environment variables:
 
 If you already have a Fabric capacity and workspace, set `byo` mode so the deployment skips creating new ones. The bicepparam variables are driven by environment variables, so the recommended approach is to set them with `azd env set` before running `azd up`:
 
-**Step 1 — Set the mode in `infra/main.bicepparam`** (or leave the default `byo` unchanged):
+**Step 1 — Set the mode** (the checked-in default is `create`, so override it to `byo`):
 
 ```bicep
 // infra/main.bicepparam
-var fabricCapacityPreset = readEnvironmentVariable('fabricCapacityMode', 'byo')
+var fabricCapacityPreset = readEnvironmentVariable('fabricCapacityMode', 'create')
 ```
 
-The `fabricCapacityMode` env variable controls both capacity and workspace preset (they are tied together). Set it explicitly if the checked-in default has been changed:
+The `fabricCapacityMode` env variable controls both capacity and workspace preset (they are tied together). Set it explicitly to use BYO mode:
 
 ```powershell
 azd env set fabricCapacityMode byo

--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -195,7 +195,7 @@ Edit `infra/main.bicepparam` or set environment variables:
 
 If you already have a Fabric capacity and workspace, set `byo` mode so the deployment skips creating new ones. The bicepparam variables are driven by environment variables, so the recommended approach is to set them with `azd env set` before running `azd up`:
 
-**Step 1 — Set the mode** ( The default value is create `create`, so override it to `byo`):
+**Step 1 — Set the mode** ( The default value is `create`, so override it to `byo`):
 
 ```bicep
 // infra/main.bicepparam

--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -195,7 +195,7 @@ Edit `infra/main.bicepparam` or set environment variables:
 
 If you already have a Fabric capacity and workspace, set `byo` mode so the deployment skips creating new ones. The bicepparam variables are driven by environment variables, so the recommended approach is to set them with `azd env set` before running `azd up`:
 
-**Step 1 — Set the mode** (the checked-in default is `create`, so override it to `byo`):
+**Step 1 — Set the mode** ( The default value is create `create`, so override it to `byo`):
 
 ```bicep
 // infra/main.bicepparam

--- a/docs/parameter_guide.md
+++ b/docs/parameter_guide.md
@@ -32,8 +32,8 @@ The recommended way to configure Fabric mode is with `azd env set` — these val
 
 ```powershell
 # Choose one:
-azd env set fabricCapacityMode create   # create new capacity + workspace
-azd env set fabricCapacityMode byo      # reuse existing capacity + workspace (default)
+azd env set fabricCapacityMode create   # create new capacity + workspace (default if not set)
+azd env set fabricCapacityMode byo      # reuse existing capacity + workspace
 azd env set fabricCapacityMode none     # disable all Fabric automation
 ```
 


### PR DESCRIPTION
Align docs with actual default in infra/main.bicepparam (line 231) which uses 'create' not 'byo' as the fallback value.

## Purpose
This pull request updates the deployment documentation to clarify the default behavior and recommended configuration for the `fabricCapacityMode` parameter. The changes make it clearer that the default mode is `create` (not `byo`), and adjust instructions and comments to match this default.

**Documentation updates for Fabric mode configuration:**

* Updated `docs/deploymentguide.md` to clarify that the checked-in default for `fabricCapacityMode` is now `create`, and instructions now explicitly describe how to override it to `byo` mode if needed.
* Updated `docs/parameter_guide.md` to indicate that `create` is the default mode for `fabricCapacityMode` (if not set), and that `byo` is no longer the default.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->