### PR TITLE
feat: Add bring-your-own Log Analytics Workspace for Foundry app and wrapper resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Follow the deployment guide to deploy this solution to your own Azure subscripti
   | **Microsoft Purview** | Existing tenant-level Purview account (or ability to create one) |
   | **Azure CLI** | Version 2.61.0 or later |
   | **Azure Developer CLI** | Version 1.15.0 or later |
+  | **Bicep CLI** | Version 0.33.0 or later |
   | **Quota** | Sufficient Azure OpenAI quota ([check here](./docs/quota_check.md)) |
 
   > **Note:** Fabric automation is optional. To disable all Fabric automation, set `fabricCapacityPreset = 'none'` and `fabricWorkspacePreset = 'none'` in `infra/main.bicepparam`.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Follow the deployment guide to deploy this solution to your own Azure subscripti
 
 > **Note:** This solution accelerator requires **Azure Developer CLI (azd) version 1.15.0 or higher**. [Download azd here](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
 
+> **Note:** This solution accelerator also requires **Bicep CLI version 0.33.0 or higher** for compiling infrastructure templates. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install).
+
 [**📘 Click here to launch the Deployment Guide**](./docs/deploymentguide.md)
 
 <br/>

--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -239,6 +239,7 @@ After setting these variables, run `azd up` normally. The deployment will attach
 | `postgreSqlNetworkIsolation` | PostgreSQL private networking toggle (defaults to `networkIsolation`) | `networkIsolation` |
 | `useExistingVNet` | Reuse an existing VNet | `false` |
 | `existingVnetResourceId` | Existing VNet resource ID (when `useExistingVNet=true`) | `` |
+| `existingLogAnalyticsWorkspaceResourceId` | Existing Log Analytics workspace to receive Foundry app + PostgreSQL + Fabric capacity diagnostics. May live in another subscription within the same tenant. | `` |
 | `vmUserName` | Jump box VM admin username | `VM_ADMIN_USERNAME` env var or `testvmuser` |
 | `vmAdminPassword` | Jump box VM admin password | `VM_ADMIN_PASSWORD` env var |
 
@@ -268,8 +269,20 @@ To check and adjust quota settings, follow the [Quota Check Guide](./quota_check
 <details>
   <summary><b>Reusing Existing Resources</b></summary>
 
-**Log Analytics Workspace:**
-See [Parameter Guide](./parameter_guide.md) for Log Analytics reuse guidance.
+**Log Analytics Workspace (BYO observability):**
+
+By default the wrapper does not create a Log Analytics workspace or Application Insights, so the deployed Foundry application and wrapper-managed resources (PostgreSQL Flexible Server, Fabric capacity) have no telemetry sink. If you already have a centralized workspace, point the deployment at it:
+
+```powershell
+azd env set EXISTING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<workspace-name>"
+```
+
+When set, the deployment will:
+1. Create an Application Insights component in the deployment resource group, linked to your existing workspace.
+2. Route PostgreSQL diagnostic logs and metrics to your workspace.
+3. Route Fabric capacity diagnostic logs and metrics to your workspace.
+
+The workspace may live in a different resource group or subscription within the same tenant. The identity running `azd up` needs **Log Analytics Contributor** on the workspace's subscription. See the **Observability — Bring Your Own Log Analytics Workspace** section in the [Parameter Guide](./parameter_guide.md) for the full output reference (App Insights resource ID, connection string, instrumentation key).
 
 </details>
 

--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -282,7 +282,7 @@ When set, the deployment will:
 2. Route PostgreSQL diagnostic logs and metrics to your workspace.
 3. Route Fabric capacity diagnostic logs and metrics to your workspace.
 
-The workspace may live in a different resource group or subscription within the same tenant. The identity running `azd up` needs **Log Analytics Contributor** on the workspace's subscription. See the **Observability — Bring Your Own Log Analytics Workspace** section in the [Parameter Guide](./parameter_guide.md) for the full output reference (App Insights resource ID, connection string, instrumentation key).
+The workspace may live in a different resource group or subscription within the same tenant. The identity running `azd up` needs **`Microsoft.Insights/diagnosticSettings/write`** on the workspace itself (covered by the built-in **Log Analytics Contributor** role scoped to the workspace or its resource group — subscription-wide rights are not required). See the **Observability — Bring Your Own Log Analytics Workspace** section in the [Parameter Guide](./parameter_guide.md) for the full output reference (App Insights resource ID, connection string, instrumentation key) and notes on deployment-history exposure of those values.
 
 </details>
 

--- a/docs/deploymentguide.md
+++ b/docs/deploymentguide.md
@@ -25,6 +25,7 @@ To deploy this solution accelerator, ensure you have access to an [Azure subscri
 |------|----------------|--------------|
 | Azure CLI | 2.61.0+ | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | Azure Developer CLI (azd) | 1.15.0+ | [Install azd](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) |
+| Bicep CLI | 0.33.0+ | [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) |
 | Git | Latest | [Install Git](https://git-scm.com/downloads) |
 | PowerShell | 7.0+ | [Install PowerShell](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) |
 

--- a/docs/parameter_guide.md
+++ b/docs/parameter_guide.md
@@ -82,6 +82,49 @@ param fabricCapacitySku = 'F2'  // adjust SKU as needed
 
 ---
 
+## Observability — Bring Your Own Log Analytics Workspace
+
+By default the wrapper sets `deployLogAnalytics = false`, so the AI Landing Zone does not create a new Log Analytics workspace and Application Insights is not provisioned. If you already have a centralized Log Analytics workspace (for example one shared across the platform), you can wire the deployed Foundry application and the wrapper-managed resources (PostgreSQL Flexible Server, Fabric capacity) to it.
+
+### How it works
+
+When you set `existingLogAnalyticsWorkspaceResourceId`:
+
+1. An **Application Insights** component is created in the deployment resource group and linked to your existing workspace via `WorkspaceResourceId`. Its name follows the same `appInsightsName` convention (`appi-<resourceToken>`).
+2. **PostgreSQL Flexible Server** diagnostic settings (all logs + AllMetrics) are routed to your workspace.
+3. **Fabric capacity** diagnostic settings (all logs + AllMetrics) are routed to your workspace.
+4. The connection string and instrumentation key are exposed as deployment outputs so post-provision automation (or your application configuration) can pick them up.
+
+> **Note:** This is wrapper-side wiring. The upstream AI Landing Zone submodule does not natively support a BYO Log Analytics workspace, so leave `deployLogAnalytics = false` and `deployAppInsights = true` (the defaults) when using BYO so the LAZ does not create its own workspace + Application Insights pair.
+
+### Setting it via azd env
+
+```powershell
+azd env set EXISTING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<workspace-name>"
+```
+
+Or set it directly in `infra/main.bicepparam`:
+
+```bicep
+param existingLogAnalyticsWorkspaceResourceId = '/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<workspace-name>'
+```
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `existingLogAnalyticsWorkspaceResourceIdOut` | Echo of the supplied workspace resource ID |
+| `byoApplicationInsightsResourceId` | Resource ID of the App Insights component created against the BYO workspace |
+| `byoApplicationInsightsName` | Name of the App Insights component |
+| `byoApplicationInsightsConnectionString` | Connection string for app instrumentation |
+| `byoApplicationInsightsInstrumentationKey` | Instrumentation key for legacy SDKs |
+
+### Permissions
+
+The identity running the deployment needs **Log Analytics Contributor** (or equivalent) on the existing workspace to attach diagnostic settings and link the new Application Insights component.
+
+---
+
 ## Table of Contents
 1. [Basic Parameters](#basic-parameters)
 2. [Deployment Toggles](#deployment-toggles)

--- a/docs/parameter_guide.md
+++ b/docs/parameter_guide.md
@@ -119,9 +119,15 @@ param existingLogAnalyticsWorkspaceResourceId = '/subscriptions/<sub-id>/resourc
 | `byoApplicationInsightsConnectionString` | Connection string for app instrumentation |
 | `byoApplicationInsightsInstrumentationKey` | Instrumentation key for legacy SDKs |
 
+> **Sensitive outputs:** The connection string and instrumentation key are bootstrap credentials for sending telemetry to your Application Insights resource. They are emitted as deployment outputs so post-provision scripts and `azd` env can wire them into application configuration. Anyone with read access to the deployment history (subscription/RG `Microsoft.Resources/deployments/read`) can retrieve these values — keep that access scoped appropriately.
+
 ### Permissions
 
-The identity running the deployment needs **Log Analytics Contributor** (or equivalent) on the existing workspace to attach diagnostic settings and link the new Application Insights component.
+The identity running the deployment needs permission to attach diagnostic settings to the workspace and to create the Application Insights component:
+
+- **`Microsoft.Insights/diagnosticSettings/write`** on the BYO Log Analytics workspace (or its resource group). The built-in **Log Analytics Contributor** role on the workspace (or its RG) covers this — there is no need to grant subscription-wide rights.
+- **`Microsoft.Insights/components/write`** on the deployment resource group (covered by **Contributor** on the deployment RG, which the deployment identity already needs to provision the rest of the stack).
+- The PostgreSQL Flexible Server and Fabric capacity that emit diagnostics are wrapper-managed in the deployment RG, so no additional cross-resource permissions are required.
 
 ---
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -615,4 +615,5 @@ output byoApplicationInsightsResourceId string = byoCreateAppInsights ? byoAppIn
 output byoApplicationInsightsName string = byoCreateAppInsights ? byoAppInsights.name : ''
 #disable-next-line outputs-should-not-contain-secrets
 output byoApplicationInsightsConnectionString string = byoCreateAppInsights ? byoAppInsights.properties.ConnectionString : ''
+#disable-next-line outputs-should-not-contain-secrets
 output byoApplicationInsightsInstrumentationKey string = byoCreateAppInsights ? byoAppInsights.properties.InstrumentationKey : ''

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -412,7 +412,7 @@ var postgreSqlPrivateEndpoints = postgreSqlNetworkIsolation ? [
 // BYO Log Analytics Workspace (observability for the Foundry application
 // and wrapper-managed resources). When existingLogAnalyticsWorkspaceResourceId
 // is provided, diagnostic settings on wrapper-managed resources
-// (PostgreSQL, Fabric capacity) are routed to that workspace. An
+// (currently PostgreSQL) are routed to that workspace. An
 // Application Insights component is created in this resource group and
 // linked to that workspace only when BYO Log Analytics is enabled,
 // deployAppInsights is true, and deployLogAnalytics is false.
@@ -511,33 +511,6 @@ module fabricCapacity 'modules/fabric-capacity.bicep' = if (effectiveFabricCapac
     ? [deployer().objectId]
     : [deployer().userPrincipalName], fabricCapacityAdmins)
     tags: deploymentTags
-  }
-}
-
-resource fabricCapacityResource 'Microsoft.Fabric/capacities@2023-11-01' existing = if (effectiveFabricCapacityMode == 'create' && byoLogAnalyticsEnabled) {
-  name: capacityName
-  dependsOn: [
-    fabricCapacity
-  ]
-}
-
-resource fabricCapacityDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (effectiveFabricCapacityMode == 'create' && byoLogAnalyticsEnabled) {
-  name: 'send-to-byo-law'
-  scope: fabricCapacityResource
-  properties: {
-    workspaceId: existingLogAnalyticsWorkspaceResourceId
-    logs: [
-      {
-        categoryGroup: 'allLogs'
-        enabled: true
-      }
-    ]
-    metrics: [
-      {
-        category: 'AllMetrics'
-        enabled: true
-      }
-    ]
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -411,9 +411,11 @@ var postgreSqlPrivateEndpoints = postgreSqlNetworkIsolation ? [
 // ----------------------------------------------------------------------
 // BYO Log Analytics Workspace (observability for the Foundry application
 // and wrapper-managed resources). When existingLogAnalyticsWorkspaceResourceId
-// is provided, an Application Insights component is created in this
-// resource group and linked to that workspace, and diagnostic settings on
-// wrapper-managed resources (PostgreSQL, Fabric capacity) are routed to it.
+// is provided, diagnostic settings on wrapper-managed resources
+// (PostgreSQL, Fabric capacity) are routed to that workspace. An
+// Application Insights component is created in this resource group and
+// linked to that workspace only when BYO Log Analytics is enabled,
+// deployAppInsights is true, and deployLogAnalytics is false.
 // ----------------------------------------------------------------------
 var byoLogAnalyticsEnabled = !empty(existingLogAnalyticsWorkspaceResourceId)
 var byoCreateAppInsights = byoLogAnalyticsEnabled && deployAppInsights && !deployLogAnalytics

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -111,6 +111,9 @@ param aiFoundryStorageAccountResourceId string = ''
 param aiFoundryCosmosDBAccountResourceId string = ''
 param keyVaultResourceId string = ''
 
+@description('Optional. Full ARM resource ID of an existing Log Analytics workspace to use for observability of the deployed Foundry application and wrapper-managed resources (PostgreSQL, Fabric capacity). When provided, an Application Insights component is created in the deployment resource group and linked to this workspace, and diagnostic settings on the wrapper-managed resources are routed to it. Leave empty to skip BYO behavior. Format: /subscriptions/{subId}/resourceGroups/{rg}/providers/Microsoft.OperationalInsights/workspaces/{name}.')
+param existingLogAnalyticsWorkspaceResourceId string = ''
+
 @description('Identity options.')
 param useUAI bool = false
 param useCAppAPIKey bool = false
@@ -405,6 +408,49 @@ var postgreSqlPrivateEndpoints = postgreSqlNetworkIsolation ? [
   }
 ] : []
 
+// ----------------------------------------------------------------------
+// BYO Log Analytics Workspace (observability for the Foundry application
+// and wrapper-managed resources). When existingLogAnalyticsWorkspaceResourceId
+// is provided, an Application Insights component is created in this
+// resource group and linked to that workspace, and diagnostic settings on
+// wrapper-managed resources (PostgreSQL, Fabric capacity) are routed to it.
+// ----------------------------------------------------------------------
+var byoLogAnalyticsEnabled = !empty(existingLogAnalyticsWorkspaceResourceId)
+var byoCreateAppInsights = byoLogAnalyticsEnabled && deployAppInsights && !deployLogAnalytics
+
+resource byoAppInsights 'Microsoft.Insights/components@2020-02-02' = if (byoCreateAppInsights) {
+  name: appInsightsName
+  location: effectiveLocation
+  kind: 'web'
+  tags: deploymentTags
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: existingLogAnalyticsWorkspaceResourceId
+    DisableIpMasking: false
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+  }
+}
+
+var postgreSqlDiagnosticSettings = (deployPostgreSql && byoLogAnalyticsEnabled) ? [
+  {
+    name: 'send-to-byo-law'
+    workspaceResourceId: existingLogAnalyticsWorkspaceResourceId
+    logCategoriesAndGroups: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metricCategories: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+] : []
+
 module postgreSqlFlexibleServer 'br/public:avm/res/db-for-postgre-sql/flexible-server:0.15.2' = if (deployPostgreSql) {
   name: 'postgresql-flexible'
   params: {
@@ -424,6 +470,7 @@ module postgreSqlFlexibleServer 'br/public:avm/res/db-for-postgre-sql/flexible-s
     version: postgreSqlVersion
     storageSizeGB: postgreSqlStorageSizeGB
     privateEndpoints: postgreSqlPrivateEndpoints
+    diagnosticSettings: postgreSqlDiagnosticSettings
     tags: deploymentTags
   }
 }
@@ -462,6 +509,33 @@ module fabricCapacity 'modules/fabric-capacity.bicep' = if (effectiveFabricCapac
     ? [deployer().objectId]
     : [deployer().userPrincipalName], fabricCapacityAdmins)
     tags: deploymentTags
+  }
+}
+
+resource fabricCapacityResource 'Microsoft.Fabric/capacities@2023-11-01' existing = if (effectiveFabricCapacityMode == 'create' && byoLogAnalyticsEnabled) {
+  name: capacityName
+  dependsOn: [
+    fabricCapacity
+  ]
+}
+
+resource fabricCapacityDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (effectiveFabricCapacityMode == 'create' && byoLogAnalyticsEnabled) {
+  name: 'send-to-byo-law'
+  scope: fabricCapacityResource
+  properties: {
+    workspaceId: existingLogAnalyticsWorkspaceResourceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
   }
 }
 
@@ -532,3 +606,11 @@ output desiredFabricWorkspaceName string = effectiveFabricWorkspaceName
 // Purview outputs (for post-provision scripts)
 output purviewAccountResourceId string = purviewAccountResourceId
 output purviewCollectionName string = !empty(purviewCollectionName) ? purviewCollectionName : (!empty(environmentName) ? 'collection-${environmentName}' : 'collection-${baseName}')
+
+// Observability outputs (BYO Log Analytics Workspace)
+output existingLogAnalyticsWorkspaceResourceIdOut string = existingLogAnalyticsWorkspaceResourceId
+output byoApplicationInsightsResourceId string = byoCreateAppInsights ? byoAppInsights.id : ''
+output byoApplicationInsightsName string = byoCreateAppInsights ? byoAppInsights.name : ''
+#disable-next-line outputs-should-not-contain-secrets
+output byoApplicationInsightsConnectionString string = byoCreateAppInsights ? byoAppInsights.properties.ConnectionString : ''
+output byoApplicationInsightsInstrumentationKey string = byoCreateAppInsights ? byoAppInsights.properties.InstrumentationKey : ''

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -25,8 +25,11 @@ param existingVnetResourceId = readEnvironmentVariable('EXISTING_VNET_RESOURCE_I
 
 // BYO Log Analytics Workspace for observability of the deployed Foundry
 // application and wrapper-managed resources (PostgreSQL, Fabric capacity).
-// When provided, an Application Insights component is created in this RG and
-// linked to this workspace. Leave empty to skip BYO behavior.
+// When provided, diagnostic settings on the wrapper-managed resources are
+// routed to this workspace. An Application Insights component is also
+// created in this RG and linked to the workspace, but only when
+// deployAppInsights is true and deployLogAnalytics is false (the wrapper
+// defaults). Leave empty to skip BYO behavior.
 // Format: /subscriptions/{subId}/resourceGroups/{rg}/providers/Microsoft.OperationalInsights/workspaces/{name}
 param existingLogAnalyticsWorkspaceResourceId = readEnvironmentVariable('EXISTING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID', '')
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -23,6 +23,13 @@ param keyVaultResourceId = ''
 param useExistingVNet = false
 param existingVnetResourceId = readEnvironmentVariable('EXISTING_VNET_RESOURCE_ID', '')
 
+// BYO Log Analytics Workspace for observability of the deployed Foundry
+// application and wrapper-managed resources (PostgreSQL, Fabric capacity).
+// When provided, an Application Insights component is created in this RG and
+// linked to this workspace. Leave empty to skip BYO behavior.
+// Format: /subscriptions/{subId}/resourceGroups/{rg}/providers/Microsoft.OperationalInsights/workspaces/{name}
+param existingLogAnalyticsWorkspaceResourceId = readEnvironmentVariable('EXISTING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID', '')
+
 // Optional additional Entra object IDs to grant Search roles.
 param aiSearchAdditionalAccessObjectIds = []
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "10203842773715246176"
+      "version": "0.43.1.21952",
+      "templateHash": "11455293291109344813"
     },
     "description": "Deploys AI Landing Zone with Fabric capacity extension"
   },
@@ -353,6 +353,13 @@
     "keyVaultResourceId": {
       "type": "string",
       "defaultValue": ""
+    },
+    "existingLogAnalyticsWorkspaceResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Full ARM resource ID of an existing Log Analytics workspace to use for observability of the deployed Foundry application and wrapper-managed resources (PostgreSQL, Fabric capacity). When provided, an Application Insights component is created in the deployment resource group and linked to this workspace, and diagnostic settings on the wrapper-managed resources are routed to it. Leave empty to skip BYO behavior. Format: /subscriptions/{subId}/resourceGroups/{rg}/providers/Microsoft.OperationalInsights/workspaces/{name}."
+      }
     },
     "useUAI": {
       "type": "bool",
@@ -825,6 +832,9 @@
     "effectiveKeyVaultResourceId": "[if(not(empty(parameters('keyVaultResourceId'))), parameters('keyVaultResourceId'), resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')))]",
     "effectivePostgreSqlAdminPassword": "[if(equals(parameters('postgreSqlAdminPassword'), '$(secretOrRandomPassword)'), format('{0}!{1}', uniqueString(subscription().id, resourceGroup().id, parameters('postgreSqlServerName')), replace(parameters('generatedPostgreSqlAdminPassword'), '-', '')), parameters('postgreSqlAdminPassword'))]",
     "postgreSqlPrivateEndpoints": "[if(parameters('postgreSqlNetworkIsolation'), createArray(createObject('name', variables('postgreSqlPrivateEndpointName'), 'subnetResourceId', format('{0}/subnets/{1}', variables('effectiveVnetResourceId'), parameters('peSubnetName')), 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('privateDnsZoneResourceId', resourceId('Microsoft.Network/privateDnsZones', variables('postgreSqlPrivateDnsZoneName'))))))), createArray())]",
+    "byoLogAnalyticsEnabled": "[not(empty(parameters('existingLogAnalyticsWorkspaceResourceId')))]",
+    "byoCreateAppInsights": "[and(and(variables('byoLogAnalyticsEnabled'), parameters('deployAppInsights')), not(parameters('deployLogAnalytics')))]",
+    "postgreSqlDiagnosticSettings": "[if(and(parameters('deployPostgreSql'), variables('byoLogAnalyticsEnabled')), createArray(createObject('name', 'send-to-byo-law', 'workspaceResourceId', parameters('existingLogAnalyticsWorkspaceResourceId'), 'logCategoriesAndGroups', createArray(createObject('categoryGroup', 'allLogs', 'enabled', true())), 'metricCategories', createArray(createObject('category', 'AllMetrics', 'enabled', true())))), createArray())]",
     "effectiveAiSearchResourceId": "[if(not(empty(parameters('aiSearchResourceId'))), parameters('aiSearchResourceId'), resourceId('Microsoft.Search/searchServices', parameters('searchServiceName')))]",
     "effectiveStorageAccountResourceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
     "effectiveFabricWorkspaceName": "[if(equals(variables('effectiveFabricWorkspaceMode'), 'byo'), if(not(empty(parameters('fabricWorkspaceName'))), parameters('fabricWorkspaceName'), if(not(empty(parameters('environmentName'))), format('workspace-{0}', parameters('environmentName')), format('workspace-{0}', parameters('baseName')))), if(not(empty(parameters('environmentName'))), format('workspace-{0}', parameters('environmentName')), format('workspace-{0}', parameters('baseName'))))]",
@@ -2409,6 +2419,22 @@
         "postgreSqlPrivateDnsZone"
       ]
     },
+    "byoAppInsights": {
+      "condition": "[variables('byoCreateAppInsights')]",
+      "type": "Microsoft.Insights/components",
+      "apiVersion": "2020-02-02",
+      "name": "[parameters('appInsightsName')]",
+      "location": "[variables('effectiveLocation')]",
+      "kind": "web",
+      "tags": "[parameters('deploymentTags')]",
+      "properties": {
+        "Application_Type": "web",
+        "WorkspaceResourceId": "[parameters('existingLogAnalyticsWorkspaceResourceId')]",
+        "DisableIpMasking": false,
+        "publicNetworkAccessForIngestion": "Enabled",
+        "publicNetworkAccessForQuery": "Enabled"
+      }
+    },
     "postgreSqlFlexibleServerResource": {
       "condition": "[parameters('deployPostgreSql')]",
       "existing": true,
@@ -2437,6 +2463,41 @@
       "properties": {
         "value": "[variables('effectivePostgreSqlAdminPassword')]"
       }
+    },
+    "fabricCapacityResource": {
+      "condition": "[and(equals(variables('effectiveFabricCapacityMode'), 'create'), variables('byoLogAnalyticsEnabled'))]",
+      "existing": true,
+      "type": "Microsoft.Fabric/capacities",
+      "apiVersion": "2023-11-01",
+      "name": "[variables('capacityName')]",
+      "dependsOn": [
+        "fabricCapacity"
+      ]
+    },
+    "fabricCapacityDiagnostics": {
+      "condition": "[and(equals(variables('effectiveFabricCapacityMode'), 'create'), variables('byoLogAnalyticsEnabled'))]",
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "apiVersion": "2021-05-01-preview",
+      "scope": "[resourceId('Microsoft.Fabric/capacities', variables('capacityName'))]",
+      "name": "send-to-byo-law",
+      "properties": {
+        "workspaceId": "[parameters('existingLogAnalyticsWorkspaceResourceId')]",
+        "logs": [
+          {
+            "categoryGroup": "allLogs",
+            "enabled": true
+          }
+        ],
+        "metrics": [
+          {
+            "category": "AllMetrics",
+            "enabled": true
+          }
+        ]
+      },
+      "dependsOn": [
+        "fabricCapacity"
+      ]
     },
     "postgreSqlFlexibleServer": {
       "condition": "[parameters('deployPostgreSql')]",
@@ -2490,6 +2551,9 @@
           },
           "privateEndpoints": {
             "value": "[variables('postgreSqlPrivateEndpoints')]"
+          },
+          "diagnosticSettings": {
+            "value": "[variables('postgreSqlDiagnosticSettings')]"
           },
           "tags": {
             "value": "[parameters('deploymentTags')]"
@@ -5114,8 +5178,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "12325469206187179338"
+              "version": "0.43.1.21952",
+              "templateHash": "2514295757830674592"
             }
           },
           "parameters": {
@@ -5353,6 +5417,26 @@
     "purviewCollectionName": {
       "type": "string",
       "value": "[if(not(empty(parameters('purviewCollectionName'))), parameters('purviewCollectionName'), if(not(empty(parameters('environmentName'))), format('collection-{0}', parameters('environmentName')), format('collection-{0}', parameters('baseName'))))]"
+    },
+    "existingLogAnalyticsWorkspaceResourceIdOut": {
+      "type": "string",
+      "value": "[parameters('existingLogAnalyticsWorkspaceResourceId')]"
+    },
+    "byoApplicationInsightsResourceId": {
+      "type": "string",
+      "value": "[if(variables('byoCreateAppInsights'), resourceId('Microsoft.Insights/components', parameters('appInsightsName')), '')]"
+    },
+    "byoApplicationInsightsName": {
+      "type": "string",
+      "value": "[if(variables('byoCreateAppInsights'), parameters('appInsightsName'), '')]"
+    },
+    "byoApplicationInsightsConnectionString": {
+      "type": "string",
+      "value": "[if(variables('byoCreateAppInsights'), reference('byoAppInsights').ConnectionString, '')]"
+    },
+    "byoApplicationInsightsInstrumentationKey": {
+      "type": "string",
+      "value": "[if(variables('byoCreateAppInsights'), reference('byoAppInsights').InstrumentationKey, '')]"
     }
   }
 }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.1.21952",
-      "templateHash": "11455293291109344813"
+      "version": "0.43.8.12551",
+      "templateHash": "1222454929578026913"
     },
     "description": "Deploys AI Landing Zone with Fabric capacity extension"
   },
@@ -2463,41 +2463,6 @@
       "properties": {
         "value": "[variables('effectivePostgreSqlAdminPassword')]"
       }
-    },
-    "fabricCapacityResource": {
-      "condition": "[and(equals(variables('effectiveFabricCapacityMode'), 'create'), variables('byoLogAnalyticsEnabled'))]",
-      "existing": true,
-      "type": "Microsoft.Fabric/capacities",
-      "apiVersion": "2023-11-01",
-      "name": "[variables('capacityName')]",
-      "dependsOn": [
-        "fabricCapacity"
-      ]
-    },
-    "fabricCapacityDiagnostics": {
-      "condition": "[and(equals(variables('effectiveFabricCapacityMode'), 'create'), variables('byoLogAnalyticsEnabled'))]",
-      "type": "Microsoft.Insights/diagnosticSettings",
-      "apiVersion": "2021-05-01-preview",
-      "scope": "[resourceId('Microsoft.Fabric/capacities', variables('capacityName'))]",
-      "name": "send-to-byo-law",
-      "properties": {
-        "workspaceId": "[parameters('existingLogAnalyticsWorkspaceResourceId')]",
-        "logs": [
-          {
-            "categoryGroup": "allLogs",
-            "enabled": true
-          }
-        ],
-        "metrics": [
-          {
-            "category": "AllMetrics",
-            "enabled": true
-          }
-        ]
-      },
-      "dependsOn": [
-        "fabricCapacity"
-      ]
     },
     "postgreSqlFlexibleServer": {
       "condition": "[parameters('deployPostgreSql')]",
@@ -5178,8 +5143,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.1.21952",
-              "templateHash": "2514295757830674592"
+              "version": "0.43.8.12551",
+              "templateHash": "11293123033508500089"
             }
           },
           "parameters": {


### PR DESCRIPTION
## Purpose
This pull request introduces support for "Bring Your Own" (BYO) Log Analytics Workspace for observability of the deployed Foundry application and wrapper-managed resources (PostgreSQL Flexible Server, Fabric capacity). It allows users to supply an existing Log Analytics workspace, to which diagnostic logs and metrics from these resources will be routed. The documentation and infrastructure templates have been updated to reflect these changes, including new parameters, outputs, and guidance.

**BYO Log Analytics Workspace (Observability) Support:**

* Added a new parameter `existingLogAnalyticsWorkspaceResourceId` in `infra/main.bicep`, `infra/main.json`, and `infra/main.bicepparam` to allow specifying an existing Log Analytics workspace for observability. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R114-R116) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R357-R363) [[3]](diffhunk://#diff-c274a6091f4ca06948f0fe1ab8681ec4eb6b4e98c4be09717a2e3cacd1344727R26-R32)
* When a workspace is provided, the deployment creates an Application Insights component linked to the workspace and configures diagnostic settings for PostgreSQL Flexible Server and Fabric capacity to send logs/metrics to it. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R411-R453) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R473) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R515-R541) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R2422-R2437) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R2467-R2501) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R2555-R2557)
* New outputs expose the resource IDs, connection strings, and instrumentation keys for the created Application Insights component, making them available for post-deployment automation or application configuration.

**Documentation Updates:**

* Updated the deployment and parameter guides (`README.md`, `docs/deploymentguide.md`, `docs/parameter_guide.md`) to document the new BYO Log Analytics Workspace feature, including usage instructions, permissions required, and output references. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R85-R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135) [[3]](diffhunk://#diff-7da2b2ea366c9b02288cd8c19cd2695f34b66c636334b3ba3fcb31c96c35ecc9R28) [[4]](diffhunk://#diff-7da2b2ea366c9b02288cd8c19cd2695f34b66c636334b3ba3fcb31c96c35ecc9R242) [[5]](diffhunk://#diff-7da2b2ea366c9b02288cd8c19cd2695f34b66c636334b3ba3fcb31c96c35ecc9L270-R285) [[6]](diffhunk://#diff-b75bd01003dbd9073f81a337499d36462abafb67b80b72cb6dffea5c772b99a0R85-R127)
* Added Bicep CLI as a required prerequisite in documentation to reflect its necessity for compiling infrastructure templates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R85-R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135) [[3]](diffhunk://#diff-7da2b2ea366c9b02288cd8c19cd2695f34b66c636334b3ba3fcb31c96c35ecc9R28)

**Infrastructure Template Updates:**

* Updated the Bicep and generated ARM templates (`infra/main.bicep`, `infra/main.json`) to support the new observability parameter and logic, including conditional resource creation and diagnostic settings. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R114-R116) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R411-R453) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R473) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R515-R541) [[5]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R609-R616) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R357-R363) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R835-R837) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R2422-R2437) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R2467-R2501) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R2555-R2557) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L5117-R5182)
* Updated Bicep/ARM template generator version to ensure compatibility with new features. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L5117-R5182)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->