### PR TITLE
chore: Add tags in resource group when deployment is in pre-provision state

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -218,10 +218,12 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2025-04-01' = {
     tags: union(
        deploymentTags,
       {
+        'azd-env-name': environmentName
         TemplateName: 'Deploy Your AI Application in Prod'
         Type: networkIsolation ? 'WAF' : 'Non-WAF'
         CreatedBy: createdBy
         DeploymentName: deployment().name
+        Location: location
       }
     )
   }

--- a/scripts/preprovision-integrated.ps1
+++ b/scripts/preprovision-integrated.ps1
@@ -222,7 +222,6 @@ $typeTag = if ($networkIsolationValue -eq 'true') { 'WAF' } else { 'Non-WAF' }
 
 $rgTags = @(
     "TemplateName=Deploy Your AI Application in Prod"
-    "Type=$typeTag"
     "CreatedBy=$createdBy"
     "Location=$($env:AZURE_LOCATION)"
 )

--- a/scripts/preprovision-integrated.ps1
+++ b/scripts/preprovision-integrated.ps1
@@ -194,6 +194,57 @@ if ([string]::IsNullOrWhiteSpace($Location) -or [string]::IsNullOrWhiteSpace($Re
     exit 1
 }
 
+# ========================================
+# [0] Pre-create resource group with tags
+# ========================================
+Write-Host "[0] Ensuring resource group exists with tags..." -ForegroundColor Cyan
+
+# Determine CreatedBy (matches Bicep logic: UPN prefix or objectId)
+$createdBy = $null
+try {
+    $upn = (& az ad signed-in-user show --query userPrincipalName -o tsv 2>$null)
+    if (-not [string]::IsNullOrWhiteSpace($upn)) {
+        $createdBy = $upn.Split('@')[0]
+    }
+} catch { }
+if ([string]::IsNullOrWhiteSpace($createdBy)) {
+    try {
+        $createdBy = (& az ad signed-in-user show --query id -o tsv 2>$null)
+    } catch { }
+}
+if ([string]::IsNullOrWhiteSpace($createdBy)) {
+    $createdBy = $env:USERNAME
+}
+
+# Type tag based on networkIsolation setting
+$networkIsolationValue = $env:NETWORK_ISOLATION
+$typeTag = if ($networkIsolationValue -eq 'true') { 'WAF' } else { 'Non-WAF' }
+
+$rgTags = @(
+    "TemplateName=Deploy Your AI Application in Prod"
+    "Type=$typeTag"
+    "CreatedBy=$createdBy"
+    "Location=$($env:AZURE_LOCATION)"
+)
+
+$rgExists = (& az group exists --name $ResourceGroup --subscription $SubscriptionId 2>$null)
+if ($rgExists -eq 'true') {
+    # RG exists — merge tags without removing existing ones
+    & az tag update `
+        --resource-id "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup" `
+        --operation Merge `
+        --tags @rgTags `
+        --only-show-errors | Out-Null
+}
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "[X] Failed to create/update resource group '$ResourceGroup' with tags." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "    [+] Resource group '$ResourceGroup' ready with tags" -ForegroundColor Green
+Write-Host ""
+
 # Navigate to AI Landing Zone submodule
 $aiLandingZonePath = Join-Path $PSScriptRoot ".." "submodules" "ai-landing-zone"
 

--- a/scripts/preprovision-integrated.sh
+++ b/scripts/preprovision-integrated.sh
@@ -101,7 +101,6 @@ if [ "$RG_EXISTS" = "true" ]; then
         --operation Merge \
         --tags \
         "TemplateName=Deploy Your AI Application in Prod" \
-        "Type=$TYPE_TAG" \
         "CreatedBy=$CREATED_BY" \
         "Location=$AZURE_LOCATION" \
         --only-show-errors > /dev/null

--- a/scripts/preprovision-integrated.sh
+++ b/scripts/preprovision-integrated.sh
@@ -70,6 +70,51 @@ if [ -z "${AZURE_LOCATION}" ] || [ -z "${AZURE_RESOURCE_GROUP}" ] || [ -z "${AZU
     exit 1
 fi
 
+# ========================================
+# [0] Pre-create resource group with tags
+# ========================================
+echo "[0] Ensuring resource group exists with tags..."
+
+# Determine CreatedBy (matches Bicep logic: UPN prefix or objectId)
+CREATED_BY=""
+CREATED_BY="$(az ad signed-in-user show --query userPrincipalName -o tsv 2>/dev/null | cut -d@ -f1 || true)"
+if [ -z "$CREATED_BY" ]; then
+    CREATED_BY="$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)"
+fi
+if [ -z "$CREATED_BY" ]; then
+    CREATED_BY="${USER:-unknown}"
+fi
+
+# Type tag based on networkIsolation setting
+NETWORK_ISOLATION_VALUE="${NETWORK_ISOLATION:-false}"
+if [ "$NETWORK_ISOLATION_VALUE" = "true" ]; then
+    TYPE_TAG="WAF"
+else
+    TYPE_TAG="Non-WAF"
+fi
+
+RG_EXISTS="$(az group exists --name "$AZURE_RESOURCE_GROUP" --subscription "$AZURE_SUBSCRIPTION_ID" 2>/dev/null || echo 'false')"
+if [ "$RG_EXISTS" = "true" ]; then
+    # RG exists — merge tags without removing existing ones
+    az tag update \
+        --resource-id "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$AZURE_RESOURCE_GROUP" \
+        --operation Merge \
+        --tags \
+        "TemplateName=Deploy Your AI Application in Prod" \
+        "Type=$TYPE_TAG" \
+        "CreatedBy=$CREATED_BY" \
+        "Location=$AZURE_LOCATION" \
+        --only-show-errors > /dev/null
+fi
+
+if [ $? -ne 0 ]; then
+    echo "[X] Failed to update resource group '$AZURE_RESOURCE_GROUP' with tags."
+    exit 1
+fi
+
+echo "    [+] Resource group '$AZURE_RESOURCE_GROUP' ready with tags"
+echo ""
+
 # Check if submodule exists
 AI_LANDING_ZONE_PATH="$REPO_ROOT/submodules/ai-landing-zone/bicep"
 


### PR DESCRIPTION
## Purpose
This pull request improves the way resource group tags are handled during deployment, ensuring consistency and completeness of metadata across both infrastructure code and provisioning scripts. The main enhancements include pre-creating or updating the resource group with a standardized set of tags and aligning tag logic between Bicep templates and provisioning scripts.

**Resource Group Tagging Improvements:**

* Both `preprovision-integrated.ps1` and `preprovision-integrated.sh` scripts now ensure the resource group exists and is updated with standardized tags before proceeding. These tags include `TemplateName`, `Type` (based on network isolation), `CreatedBy` (derived from user context), and `Location`. This logic matches the Bicep template to maintain consistency. [[1]](diffhunk://#diff-a253817bcc1b252d0c56a100d553ab281c83261a2f1a50266ca61f2e5ad0ddadR197-R247) [[2]](diffhunk://#diff-10f35e566cdb7f30791b2563e4eed53f91a42924bc27cfe96c118728745656b0R73-R117)

* The Bicep template for resource group tags (`resourceGroupTags` in `main.bicep`) is updated to add the `azd-env-name` and `Location` tags, ensuring these values are always present in the deployment metadata.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->