### PR TITLE
fix(ci): generate unique AZURE_ENV_NAME per run to avoid soft-deleted Key Vault conflict

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Generate unique env name per run
         shell: bash
         run: |
-          HHMMSS=$(date -u +'%H%M%S')
-          echo "AZURE_ENV_NAME=${AZURE_ENV_NAME}-${HHMMSS}" >> "$GITHUB_ENV"
-          echo "Using unique AZURE_ENV_NAME: ${AZURE_ENV_NAME}-${HHMMSS}"
+          SUFFIX="${GITHUB_RUN_ID}"
+          echo "AZURE_ENV_NAME=${AZURE_ENV_NAME}-${SUFFIX}" >> "$GITHUB_ENV"
+          echo "Using unique AZURE_ENV_NAME: ${AZURE_ENV_NAME}-${SUFFIX}"
 
       - name: Install azd
         uses: Azure/setup-azd@v2

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Generate unique env name per run
+        shell: bash
+        run: |
+          HHMMSS=$(date -u +'%H%M%S')
+          echo "AZURE_ENV_NAME=${AZURE_ENV_NAME}-${HHMMSS}" >> "$GITHUB_ENV"
+          echo "Using unique AZURE_ENV_NAME: ${AZURE_ENV_NAME}-${HHMMSS}"
+
       - name: Install azd
         uses: Azure/setup-azd@v2
 


### PR DESCRIPTION
## Purpose

Fixes the chronically failing **AZD Deployment** workflow (`.github/workflows/azure-dev.yml`) that has been blocked by an Azure Key Vault soft-delete name collision.

### Root cause

`infra/main.bicep` computes `resourceToken` as:

```bicep
param resourceToken string = toLower(uniqueString(subscription().id, environmentName, location))
```

Because `AZURE_ENV_NAME` is a static repository variable, every workflow run produces the same `resourceToken` — and therefore the same `kv-<token>` name. Combined with `purgeProtection: true` on the vault, once a run is torn down the next run fails with:

```
ConflictError: A vault with the same name already exists in deleted state.
```

`az keyvault purge` is rejected with `MethodNotAllowed: DeletedVaultPurge is not allowed.` because of purge protection, so the name remains reserved in soft-delete state for up to 90 days, blocking all subsequent runs.

### The fix

Add one workflow step (before `Install azd`) that appends `${GITHUB_RUN_ID}` to `AZURE_ENV_NAME` for the run, making the resulting `resourceToken` — and every name derived from it — unique per run:

```yaml
- name: Generate unique env name per run
  shell: bash
  run: |
    SUFFIX="${GITHUB_RUN_ID}"
    echo "AZURE_ENV_NAME=${AZURE_ENV_NAME}-${SUFFIX}" >> "$GITHUB_ENV"
    echo "Using unique AZURE_ENV_NAME: ${AZURE_ENV_NAME}-${SUFFIX}"
```

`GITHUB_RUN_ID` is globally unique across the repo (no 24-hour wrap-around risk vs. a time-only suffix), short enough to keep env names within azd constraints, and trivially traceable back to the originating workflow run.

The pattern aligns with what 14+ sibling Microsoft accelerator repos already do for the same reason.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The change is additive (a new step) and only mutates the in-process `AZURE_ENV_NAME` for the workflow run. Existing repo variables, secrets, and downstream consumers are unchanged.

## Golden Path Validation

- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation

- [x] I have validated the deployment process successfully and all services are running as expected with this change.

A full end-to-end run of `.github/workflows/azure-dev.yml` completed successfully (every step ✅ including `Provision Infrastructure`) against the maintenance subscription in ~42 minutes.

## What to Check

- New workflow step `Generate unique env name per run` runs before `Install azd`.
- The injected `AZURE_ENV_NAME` is propagated to subsequent steps via `$GITHUB_ENV`.
- `Create Resource Group if needed` produces a unique RG name per run.
- No other workflow inputs / repo variables need to change.

## Other Information

Related: User Story 43809.
